### PR TITLE
fix fragment overlapp on back pressed bug

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -75,7 +75,7 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
         {
             FragmentTransaction trans = getFragmentManager().beginTransaction();
             Fragment debugFragment = new Debug();
-            trans.replace(R.id.fragment_container, debugFragment);
+            trans.replace(R.id.fragment_container, debugFragment).addToBackStack(null);
             trans.commit();
             return true;
         }


### PR DESCRIPTION
Fixing small bug where when you pressed the back button after going to the debug page fragments would overlap onto each other
