### PR TITLE
Sc add question model

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -3,6 +3,7 @@ package edu.uco.schambers.classmate.Activites;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
@@ -16,6 +17,7 @@ import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
 import edu.uco.schambers.classmate.Fragments.TeacherInterface;
 import edu.uco.schambers.classmate.Fragments.TeacherQuestionResults;
 import edu.uco.schambers.classmate.Fragments.UserInformation;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 
 
@@ -29,19 +31,20 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        String intentAction = getIntent().getAction();
-        startFragmentAccordingToIntentAction(intentAction);
+        startFragmentAccordingToIntentAction(getIntent());
 
     }
 
-    private void startFragmentAccordingToIntentAction(String intentAction)
+    private void startFragmentAccordingToIntentAction(Intent intent)
     {
         FragmentTransaction trans = getFragmentManager().beginTransaction();
-        switch(intentAction)
+        switch(intent.getAction())
         {
 
             case CallForStudentQuestionResponseReceiver.ACTION_REQUEST_QUESTION_RESPONSE:
-                StudentResponseFragment studentResponseFragment= new StudentResponseFragment();
+                Bundle bundle= intent.getExtras();
+                IQuestion question =(IQuestion) bundle.getSerializable(StudentResponseFragment.ARG_QUESTION);
+                StudentResponseFragment studentResponseFragment= StudentResponseFragment.newInstance(question);
                 trans.replace(R.id.fragment_container,studentResponseFragment);
                 break;
 

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/CallForStudentQuestionResponseReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/CallForStudentQuestionResponseReceiver.java
@@ -6,9 +6,12 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 
 import edu.uco.schambers.classmate.Activites.MainActivity;
+import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
+import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
 import edu.uco.schambers.classmate.R;
 
 public class CallForStudentQuestionResponseReceiver extends BroadcastReceiver
@@ -50,6 +53,9 @@ public class CallForStudentQuestionResponseReceiver extends BroadcastReceiver
 
         Intent notifyIntent = new Intent(context, MainActivity.class);
         notifyIntent.setAction(ACTION_REQUEST_QUESTION_RESPONSE);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(StudentResponseFragment.ARG_QUESTION, new DefaultMultiChoiceQuestion());
+        notifyIntent.putExtras(bundle);
         PendingIntent notifyPendingIntent = PendingIntent.getActivity(context,0,notifyIntent,PendingIntent.FLAG_CANCEL_CURRENT);
         notificationBuilder.setContentIntent(notifyPendingIntent);
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/Debug.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/Debug.java
@@ -77,7 +77,7 @@ public class Debug extends Fragment
             @Override
             public void onClick(View v)
             {
-                Fragment studentResponse = StudentResponseFragment.newInstance("test", "test");
+                Fragment studentResponse = StudentResponseFragment.newInstance(null);
                 launchFragment(studentResponse);
             }
         });

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentInterface.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentInterface.java
@@ -126,7 +126,7 @@ public class StudentInterface extends Fragment {
             @Override
             public void onClick(View v){
 
-                Fragment response = StudentResponseFragment.newInstance("test", "test");
+                Fragment response = StudentResponseFragment.newInstance(null);
                 launchFragment(response);
 
             }

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -77,6 +77,15 @@ public class StudentResponseFragment extends Fragment
     private void initUI(final View rootView)
     {
         radioGroup = (RadioGroup) rootView.findViewById(R.id.radio_response_group);
+        radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener()
+        {
+            @Override
+            public void onCheckedChanged(RadioGroup group, int checkedId)
+            {
+                RadioButton checked = (RadioButton) rootView.findViewById(checkedId);
+                question.answerQuestion(checked.getText().toString());
+            }
+        });
         sendBtn = (Button) rootView.findViewById(R.id.btn_send_question_response);
         questionText = (TextView) rootView.findViewById(R.id.response_card_question_text);
         sendBtn.setOnClickListener(new View.OnClickListener()
@@ -84,11 +93,9 @@ public class StudentResponseFragment extends Fragment
             @Override
             public void onClick(View v)
             {
-                int selectedId = radioGroup.getCheckedRadioButtonId();
-                RadioButton selectedButton = (RadioButton) rootView.findViewById(selectedId);
-                if (selectedButton != null)
+                if (question.questionIsAnswered())
                 {
-                    sendResponse(selectedButton.getText());
+                    sendResponse(question.getAnswer());
                 }
             }
         });
@@ -113,6 +120,13 @@ public class StudentResponseFragment extends Fragment
         if(question != null)
         {
             questionText.setText(question.getQuestionText());
+            int index = 0;
+            for(String s : question.getQuestionChoices())
+            {
+                RadioButton radioButton =(RadioButton) radioGroup.getChildAt(index);
+                radioButton.setText(s);
+                index++;
+            }
         }
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -15,26 +15,17 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import edu.uco.schambers.classmate.BroadcastReceivers.CallForStudentQuestionResponseReceiver;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 
-/**
- * A simple {@link Fragment} subclass.
- * Activities that contain this fragment must implement the
- * {@link StudentResponseFragment.OnFragmentInteractionListener} interface
- * to handle interaction events.
- * Use the {@link StudentResponseFragment#newInstance} factory method to
- * create an instance of this fragment.
- */
 public class StudentResponseFragment extends Fragment
 {
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-    private static final String ARG_PARAM1 = "param1";
-    private static final String ARG_PARAM2 = "param2";
+    public static final String ARG_QUESTION= "edu.uco.schambers.classmate.arq_question";
 
     // TODO: Rename and change types of parameters
-    private String mParam1;
-    private String mParam2;
+    private IQuestion question;
 
     //UI Components
     private RadioGroup radioGroup;
@@ -43,21 +34,11 @@ public class StudentResponseFragment extends Fragment
 
     private OnFragmentInteractionListener mListener;
 
-    /**
-     * Use this factory method to create a new instance of
-     * this fragment using the provided parameters.
-     *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
-     * @return A new instance of fragment StudentResponseFragment.
-     */
-    // TODO: Rename and change types and number of parameters
-    public static StudentResponseFragment newInstance(String param1, String param2)
+    public static StudentResponseFragment newInstance(IQuestion question)
     {
         StudentResponseFragment fragment = new StudentResponseFragment();
         Bundle args = new Bundle();
-        args.putString(ARG_PARAM1, param1);
-        args.putString(ARG_PARAM2, param2);
+        args.putSerializable(ARG_QUESTION, question);
         fragment.setArguments(args);
         return fragment;
     }
@@ -73,8 +54,7 @@ public class StudentResponseFragment extends Fragment
         super.onCreate(savedInstanceState);
         if (getArguments() != null)
         {
-            mParam1 = getArguments().getString(ARG_PARAM1);
-            mParam2 = getArguments().getString(ARG_PARAM2);
+            question = (IQuestion) getArguments().getSerializable(ARG_QUESTION);
         }
     }
 
@@ -84,7 +64,13 @@ public class StudentResponseFragment extends Fragment
     {
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.fragment_student_response, container, false);
-        initUI(rootView);
+        if(question != null)
+        {
+            View questionCardView = inflater.inflate(R.layout.question_response_card,(ViewGroup)rootView);
+            initUI(questionCardView);
+            populateQuestionCardFromQuestion();
+
+        }
         return rootView;
     }
 
@@ -116,19 +102,17 @@ public class StudentResponseFragment extends Fragment
         Toast.makeText(getActivity(), String.format(getResources().getString(R.string.response_sent),text), Toast.LENGTH_SHORT).show();
     }
 
-    /**
-     * This interface must be implemented by activities that contain this
-     * fragment to allow an interaction in this fragment to be communicated
-     * to the activity and potentially other fragments contained in that
-     * activity.
-     * <p>
-     * See the Android Training lesson <a href=
-     * "http://developer.android.com/training/basics/fragments/communicating.html"
-     * >Communicating with Other Fragments</a> for more information.
-     */
+
     public interface OnFragmentInteractionListener
     {
         // TODO: Update argument type and name
         void onFragmentInteraction(Uri uri);
+    }
+    private void populateQuestionCardFromQuestion()
+    {
+        if(question != null)
+        {
+            questionText.setText(question.getQuestionText());
+        }
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -1,14 +1,17 @@
 package edu.uco.schambers.classmate.Fragments;
 
+import android.app.ActionBar;
 import android.app.PendingIntent;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.app.Fragment;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
@@ -120,13 +123,21 @@ public class StudentResponseFragment extends Fragment
         if(question != null)
         {
             questionText.setText(question.getQuestionText());
-            int index = 0;
             for(String s : question.getQuestionChoices())
             {
-                RadioButton radioButton =(RadioButton) radioGroup.getChildAt(index);
-                radioButton.setText(s);
-                index++;
+                RadioButton rb = generateRadioButtonForResponse(s);
+                radioGroup.addView(rb);
             }
         }
+    }
+    private RadioButton generateRadioButtonForResponse(String s)
+    {
+        RadioButton radioButton = new RadioButton(getActivity());
+        radioButton.setId(View.generateViewId());
+        RadioGroup.LayoutParams params = new RadioGroup.LayoutParams(RadioGroup.LayoutParams.MATCH_PARENT, RadioGroup.LayoutParams.WRAP_CONTENT);
+        radioButton.setGravity(Gravity.CENTER_VERTICAL);
+        radioButton.setLayoutParams(params);
+        radioButton.setText(s);
+        return radioButton;
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
@@ -49,4 +49,10 @@ public class DefaultMultiChoiceQuestion implements IQuestion
     {
         return responseIndex > -1;
     }
+
+    @Override
+    public String getAnswer()
+    {
+        return choiceList.get(responseIndex);
+    }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
@@ -13,13 +13,11 @@ import edu.uco.schambers.classmate.R;
  */
 public class DefaultMultiChoiceQuestion implements IQuestion
 {
-    private Context context;
     private List<String> choiceList;
     private int responseIndex;
 
-    DefaultMultiChoiceQuestion(Context context)
+    public DefaultMultiChoiceQuestion()
     {
-        this.context = context;
         choiceList = new ArrayList<>();
         choiceList.add("A");
         choiceList.add("B");
@@ -31,7 +29,7 @@ public class DefaultMultiChoiceQuestion implements IQuestion
     @Override
     public String getQuestionText()
     {
-        return context.getResources().getString(R.string.default_simple_question_description);
+        return "Your teacher has read a question and its choices aloud. Mark your response to their question below and press send.";
     }
 
     @Override

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultMultiChoiceQuestion.java
@@ -1,0 +1,54 @@
+package edu.uco.schambers.classmate.Models.Questions;
+
+import android.content.Context;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.uco.schambers.classmate.R;
+
+/**
+ * Created by Steven Chambers on 9/19/2015.
+ */
+public class DefaultMultiChoiceQuestion implements IQuestion
+{
+    private Context context;
+    private List<String> choiceList;
+    private int responseIndex;
+
+    DefaultMultiChoiceQuestion(Context context)
+    {
+        this.context = context;
+        choiceList = new ArrayList<>();
+        choiceList.add("A");
+        choiceList.add("B");
+        choiceList.add("C");
+        choiceList.add("D");
+        responseIndex = -1;
+    }
+
+    @Override
+    public String getQuestionText()
+    {
+        return context.getResources().getString(R.string.default_simple_question_description);
+    }
+
+    @Override
+    public List<String> getQuestionChoices()
+    {
+        return choiceList;
+    }
+
+    @Override
+    public void answerQuestion(String answer)
+    {
+        responseIndex = choiceList.indexOf(answer);
+    }
+
+    @Override
+    public boolean questionIsAnswered()
+    {
+        return responseIndex > -1;
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/IQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/IQuestion.java
@@ -8,8 +8,10 @@ import java.util.List;
  */
 public interface IQuestion extends Serializable
 {
-    public String getQuestionText();
-    public List<String> getQuestionChoices();
-    public void answerQuestion(String answer);
-    public boolean questionIsAnswered();
+    String getQuestionText();
+    List<String> getQuestionChoices();
+    void answerQuestion(String answer);
+    boolean questionIsAnswered();
+    String getAnswer();
+
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/IQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/IQuestion.java
@@ -1,0 +1,15 @@
+package edu.uco.schambers.classmate.Models.Questions;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Created by Steven Chambers on 9/19/2015.
+ */
+public interface IQuestion extends Serializable
+{
+    public String getQuestionText();
+    public List<String> getQuestionChoices();
+    public void answerQuestion(String answer);
+    public boolean questionIsAnswered();
+}

--- a/app/src/main/res/layout/fragment_student_response.xml
+++ b/app/src/main/res/layout/fragment_student_response.xml
@@ -4,6 +4,5 @@
              android:layout_height="match_parent"
              tools:context="edu.uco.schambers.classmate.Fragments.StudentResponseFragment">
 
-    <include layout="@layout/question_response_card"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/question_response_card.xml
+++ b/app/src/main/res/layout/question_response_card.xml
@@ -33,35 +33,6 @@
                 android:layout_margin="16dp"
                 >
 
-                <RadioButton
-                    android:id="@+id/radio_btn_a"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="start"
-                    />
-
-                <RadioButton
-                    android:id="@+id/radio_btn_b"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="start"
-                    />
-
-                <RadioButton
-                    android:id="@+id/radio_btn_c"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="start"
-                    />
-
-                <RadioButton
-                    android:id="@+id/radio_btn_d"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="start"
-                    />
-
-
             </RadioGroup>
 
             <LinearLayout

--- a/app/src/main/res/layout/question_response_card.xml
+++ b/app/src/main/res/layout/question_response_card.xml
@@ -23,7 +23,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="@string/default_simple_question_description"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
 
             <RadioGroup
@@ -39,7 +38,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start"
-                    android:text="@string/option_a"
                     />
 
                 <RadioButton
@@ -47,7 +45,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start"
-                    android:text="@string/option_b"
                     />
 
                 <RadioButton
@@ -55,7 +52,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start"
-                    android:text="@string/option_c"
                     />
 
                 <RadioButton
@@ -63,7 +59,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start"
-                    android:text="@string/option_d"
                     />
 
 


### PR DESCRIPTION
This update adds:
- A question interface defining all behaviours questions need to have in our system. This interface extends the Serializable interface, ensuring that all question objects can easilly be passed directly through sockets. 
- A default question that resembles the one previously hard coded into my interface
- Modularization to the question card layout, causing it to only be generated if a question is currently associated with the StudentResponseFragment
- Generation of relevent fields in the question card layout dependant on the contents of the question
- The passing of a question to the StudentResponseFragment **only** when the fragment is launched from the notification launched by @Perrofrijole's fragment.

Because of the behavior in the bullet listed above, when clicking on my fragment launch button, the result will be a blank layout signifying that there are currently no questions to answer (this will be clarified in the UI in a later update). The only way to see the question card from here forward will be to launch @Perrofrijole's fragment and press the send button, causing the notification that launches my fragment to appear in the system tray.
