### PR TITLE
Wz serv discover enhance

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -12,6 +12,7 @@ import android.net.wifi.p2p.WifiP2pManager.Channel;
 import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceInfo;
 import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceRequest;
 import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -45,6 +46,9 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
     public static final String SERVICE_INSTANCE = "_test";
     // For creating service request, and initiate discovery
     private WifiP2pDnsSdServiceRequest serviceRequest;
+
+    // Constants
+    public static final String SERVICE_FOUND = "edu.uco.schambers.classmate.wifip2p.service_found";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -168,6 +172,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
 
     public void discoverLocalService(){
 
+        final LocalBroadcastManager broadcaster = LocalBroadcastManager.getInstance(this);
+
         //Register listeners for DNS-SD services. These are callbacks invoked
         //by the system when a service is actually discovered.
         mManager.setDnsSdResponseListeners(mChannel,
@@ -177,6 +183,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                         // A service has been discovered. Is this our app?
                         if (instanceName.equalsIgnoreCase(SERVICE_INSTANCE)){
                             // update UI
+                            broadcaster.sendBroadcast(new Intent(MainActivity.SERVICE_FOUND));
+
                             Log.d("ServiceDiscovery", "Service found");
                         }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -175,6 +175,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
     public void discoverLocalService(){
 
         final LocalBroadcastManager broadcaster = LocalBroadcastManager.getInstance(this);
+        // String map containing information about your service.
+        final HashMap<String, String> records = new HashMap<>();
 
         //Register listeners for DNS-SD services. These are callbacks invoked
         //by the system when a service is actually discovered.
@@ -184,8 +186,20 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                     public void onDnsSdServiceAvailable(String instanceName, String registrationType, WifiP2pDevice srcDevice) {
                         // A service has been discovered. Is this our app?
                         if (instanceName.equalsIgnoreCase(SERVICE_INSTANCE)){
-                            // update UI
-                            broadcaster.sendBroadcast(new Intent(MainActivity.SERVICE_FOUND));
+
+                            Intent intent = new Intent(MainActivity.SERVICE_FOUND);
+
+                            // Traverse all the key-value pair that sent from server
+                            // and put them to intent.
+                            for (Map.Entry<String,String> entry : records.entrySet()) {
+                                String key = entry.getKey();
+                                String value = entry.getValue();
+
+                                intent.putExtra(key, value);
+                            }
+
+                            // Notify the observers to update their UI
+                            broadcaster.sendBroadcast(intent);
 
                             Log.d("ServiceDiscovery", "Service found");
                         }
@@ -196,7 +210,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                 new WifiP2pManager.DnsSdTxtRecordListener() {
                     @Override
                     public void onDnsSdTxtRecordAvailable(String fullDomainName, Map<String, String> txtRecordMap, WifiP2pDevice srcDevice) {
-
+                        // Get all the information that sent from server.
+                        records.putAll(txtRecordMap);
                     }
                 });
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -168,6 +168,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                 Toast.makeText(getApplicationContext(),errorMessage,Toast.LENGTH_SHORT).show();
             }
         });
+
+        discoverLocalService();
     }
 
     public void discoverLocalService(){

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -207,6 +207,11 @@ public class StudentRollCall extends Fragment {
                 Toast.makeText(getActivity(), "You've checked-in", Toast.LENGTH_SHORT).show();
             }
         });
+
+        // Disable the button.
+        // The check-in button can be enabled
+        // only if there is a teacher roll call service found.
+        btnCheckin.setEnabled(false);
     }
 
     private void changeAudioSetting(String audioMode){

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -105,6 +105,7 @@ public class StudentRollCall extends Fragment {
             @Override
             public void onReceive(Context context, Intent intent) {
                 btnCheckin.setEnabled(true);
+                lblCheckinStatus.setText("Professor " + intent.getStringExtra("buddyname") + "'s class has been found");
             }
         };
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -8,6 +8,9 @@
  * Edit: 9/24/2015
  *   added button onCreate method for activating Wifi discovery
  *
+ * Edit: 9/27/2015
+ *   default the check-in button to be disable
+ *   Enable check-in button and display teacher's info when a roll call service is found
  */
 
 package edu.uco.schambers.classmate.Fragments;

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -13,12 +13,16 @@
 package edu.uco.schambers.classmate.Fragments;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.app.Fragment;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -55,6 +59,8 @@ public class StudentRollCall extends Fragment {
     private TextView lblCheckinStatus;
 
     private SharedPreferences prefs;
+
+    private BroadcastReceiver receiver;
 
     private OnFragmentInteractionListener mListener;
 
@@ -93,6 +99,21 @@ public class StudentRollCall extends Fragment {
 
         setHasOptionsMenu(true);
 
+        // Our handler for received Intents. This will be called whenever an Intent
+        // with an action named "service_found" is broadcasted.
+        receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                btnCheckin.setEnabled(true);
+            }
+        };
+
+        // Register to receive messages.
+        // We are registering an observer (receiver) to receive Intents
+        // with actions named "service_found".
+        LocalBroadcastManager.getInstance(this.getActivity()).registerReceiver(receiver,
+                new IntentFilter(MainActivity.SERVICE_FOUND));
+
         // Discover teacher coll roll service
         discoverService();
     }
@@ -121,7 +142,7 @@ public class StudentRollCall extends Fragment {
         }
 
         // Set the visibility of mute and vibrate menu items
-        if (checkedInMode.equalsIgnoreCase("Mute")){
+        if (checkedInMode.equalsIgnoreCase("Mute")) {
             mute.setVisible(false);
         }
         else {
@@ -224,6 +245,13 @@ public class StudentRollCall extends Fragment {
         if (mListener != null) {
             mListener.onFragmentInteraction(uri);
         }
+    }
+
+    @Override
+    public void onDestroy() {
+        // Unregister since the fragment is about to be closed.
+        LocalBroadcastManager.getInstance(this.getActivity()).unregisterReceiver(receiver);
+        super.onDestroy();
     }
 
     /**


### PR DESCRIPTION
- Implement onDnsSdServiceAvailable and onDnsSdTxtRecordAvailable methods at MainActivity to get all the information sent from server. 
- Add BroadCastReceiver to notify of updating student roll call fragment UI. 
      - Check-in button is enabled only if a roll call service is found.
      - Status TextView displays teacher's name when a roll call service is found.
- Append the call of discoverLocalService method to addLocalService method at MainActivity. Seems increase the success rate of discovering a service. 
