### PR TITLE
Sc question transmission through sockets

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionReceivedListener.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionReceivedListener.java
@@ -1,0 +1,11 @@
+package edu.uco.schambers.classmate.ListenerInterfaces;
+
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public interface OnQuestionReceivedListener
+{
+    void onQuestionReceived(IQuestion q);
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionReceivedListener.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionReceivedListener.java
@@ -8,4 +8,5 @@ import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 public interface OnQuestionReceivedListener
 {
     void onQuestionReceived(IQuestion q);
+    void onQuestionSentSuccessfully(String domain, int port);
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
@@ -16,12 +16,17 @@ import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
+import edu.uco.schambers.classmate.SocketActions.SocketAction;
+import edu.uco.schambers.classmate.SocketActions.StudentReceiveQuestionsAction;
+import edu.uco.schambers.classmate.SocketActions.StudentSendQuestionAction;
 
 public class StudentQuestionService extends Service implements OnQuestionReceivedListener
 {
     public static final String ACTION_NOTIFY_QUESTION_RECEIVED = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_NOTIFY_QUESTION_RECEIVED";
     public static final String ACTION_REQUEST_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_REQUEST_QUESTION_RESPONSE";
     public static final String ACTION_SEND_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_SEND_QUESTION_RESPONSE";
+
+    private SocketAction listenForQuestions;
 
     public StudentQuestionService()
     {
@@ -54,7 +59,8 @@ public class StudentQuestionService extends Service implements OnQuestionReceive
     public void onCreate()
     {
         super.onCreate();
-        //will probably set up wifi p2p connection instance here when we get that far.
+        listenForQuestions = new StudentReceiveQuestionsAction(this);
+        listenForQuestions.execute();
     }
 
     @Override
@@ -79,7 +85,12 @@ public class StudentQuestionService extends Service implements OnQuestionReceive
     private void sendQuestionResponse(IQuestion question)
     {
         //todo actual implementation
-        Toast.makeText(this, String.format(getResources().getString(R.string.response_sent), question.getAnswer()), Toast.LENGTH_SHORT).show();
+        SocketAction sendQuestion = new StudentSendQuestionAction(question);
+        sendQuestion.execute();
+        if(((StudentSendQuestionAction)sendQuestion).isQuestionSentSuccessfully())
+        {
+            Toast.makeText(this, String.format(getResources().getString(R.string.response_sent), question.getAnswer()), Toast.LENGTH_SHORT).show();
+        }
     }
 
     private void notifyQuestionReceived(IQuestion question)

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
@@ -89,7 +89,6 @@ public class StudentQuestionService extends Service implements OnQuestionReceive
 
     private void sendQuestionResponse(IQuestion question)
     {
-        //todo actual implementation
         SocketAction sendQuestion = new StudentSendQuestionAction(question, this);
         sendQuestion.execute();
     }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
@@ -13,11 +13,11 @@ import android.widget.Toast;
 
 import edu.uco.schambers.classmate.Activites.MainActivity;
 import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
-import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 
-public class StudentQuestionService extends Service
+public class StudentQuestionService extends Service implements OnQuestionReceivedListener
 {
     public static final String ACTION_NOTIFY_QUESTION_RECEIVED = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_NOTIFY_QUESTION_RECEIVED";
     public static final String ACTION_REQUEST_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_REQUEST_QUESTION_RESPONSE";
@@ -108,5 +108,12 @@ public class StudentQuestionService extends Service
     {
         // TODO: Return the communication channel to the service.
         throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void onQuestionReceived(IQuestion question)
+    {
+        Intent intent = getNewSendQuestionIntent(this, question);
+        startService(intent);
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
@@ -73,7 +73,7 @@ public class StudentQuestionService extends Service implements OnQuestionReceive
                 sendQuestionResponse(question);
                 break;
         }
-        return START_NOT_STICKY;
+        return START_STICKY;
     }
 
     private void sendQuestionResponse(IQuestion question)

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -1,17 +1,45 @@
 package edu.uco.schambers.classmate.SocketActions;
 
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
 /**
  * Created by Steven Chambers on 10/3/2015.
  */
 public abstract class SocketAction
 {
-   abstract void setUpSocket();
-   abstract void performAction();
-   abstract void tearDownSocket();
+   static final int QUESTIONS_PORT_NUMBER = 8080;
+
+   abstract void setUpSocket() throws  IOException;
+   abstract void performAction() throws IOException;
+   abstract void tearDownSocket() throws  IOException;
    void execute()
    {
-      setUpSocket();
-      performAction();
-      tearDownSocket();
+      Thread executionThread = new Thread(new Runnable()
+      {
+         @Override
+         public void run()
+         {
+            try
+            {
+               setUpSocket();
+               performAction();
+               tearDownSocket();
+            }
+            catch (UnknownHostException e)
+            {
+               Log.d("StudentSendAction", "Host not found. Exception: " + e.toString());
+            }
+            catch(IOException e)
+            {
+               Log.d("StudentSendAction", "IOException: " + e.toString());
+            }
+         }
+      });
+      executionThread.start();
    }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -13,6 +13,7 @@ import java.net.UnknownHostException;
 public abstract class SocketAction
 {
    static final int QUESTIONS_PORT_NUMBER = 8080;
+   Socket socket;
 
    abstract void setUpSocket() throws  IOException;
    abstract void performAction() throws IOException;
@@ -32,11 +33,11 @@ public abstract class SocketAction
             }
             catch (UnknownHostException e)
             {
-               Log.d("StudentSendAction", "Host not found. Exception: " + e.toString());
+               Log.d("SocketAction", "Host not found. Exception: " + e.toString());
             }
             catch(IOException e)
             {
-               Log.d("StudentSendAction", "IOException: " + e.toString());
+               Log.d("SocketAction", "IOException: " + e.toString());
             }
          }
       });

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -1,0 +1,17 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public abstract class SocketAction
+{
+   abstract void setUpSocket();
+   abstract void performAction();
+   abstract void tearDownSocket();
+   void execute()
+   {
+      setUpSocket();
+      performAction();
+      tearDownSocket();
+   }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -18,7 +18,7 @@ public abstract class SocketAction
    abstract void setUpSocket() throws  IOException;
    abstract void performAction() throws IOException;
    abstract void tearDownSocket() throws  IOException;
-   void execute()
+   public void execute()
    {
       Thread executionThread = new Thread(new Runnable()
       {

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentReceiveQuestionsAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentReceiveQuestionsAction.java
@@ -48,6 +48,7 @@ public class StudentReceiveQuestionsAction extends SocketAction
             try
             {
                 IQuestion questionReceived =(IQuestion) objectInputStream.readObject();
+                questionReceivedSuccessfully = true;
                 questionReceivedListener.onQuestionReceived(questionReceived);
             }
             catch (ClassNotFoundException e)

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentReceiveQuestionsAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentReceiveQuestionsAction.java
@@ -1,0 +1,87 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+import android.util.Log;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.ServerSocket;
+
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public class StudentReceiveQuestionsAction extends SocketAction
+{
+    ObjectInputStream objectInputStream;
+    DataOutputStream dataOutputStream;
+    ServerSocket serverSocket;
+
+    OnQuestionReceivedListener questionReceivedListener;
+
+    boolean listeningForQuestions = true;
+    boolean questionReceivedSuccessfully;
+
+    public StudentReceiveQuestionsAction(OnQuestionReceivedListener listener)
+    {
+       this.questionReceivedListener = listener;
+    }
+
+    @Override
+    void setUpSocket() throws IOException
+    {
+        serverSocket = new ServerSocket(QUESTIONS_PORT_NUMBER);
+
+    }
+
+    @Override
+    void performAction() throws IOException
+    {
+        while (listeningForQuestions)
+        {
+            socket = serverSocket.accept();
+            objectInputStream = new ObjectInputStream(socket.getInputStream());
+            dataOutputStream = new DataOutputStream(socket.getOutputStream());
+
+            try
+            {
+                IQuestion questionReceived =(IQuestion) objectInputStream.readObject();
+                questionReceivedListener.onQuestionReceived(questionReceived);
+            }
+            catch (ClassNotFoundException e)
+            {
+                Log.d("SocketAction", "There was a problem decoding the serializable question. Exception: " + e.toString());
+            }
+            dataOutputStream.writeBoolean(questionReceivedSuccessfully);
+
+        }
+
+    }
+
+    @Override
+    void tearDownSocket() throws IOException
+    {
+        if(serverSocket != null)
+        {
+            serverSocket.close();
+        }
+        if(socket != null)
+        {
+            socket.close();
+        }
+        if(objectInputStream != null)
+        {
+            objectInputStream.close();
+        }
+        if(dataOutputStream != null)
+        {
+            dataOutputStream.close();
+        }
+    }
+    public void stopListening()
+    {
+        listeningForQuestions = false;
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -24,6 +24,11 @@ public class StudentSendQuestionAction extends SocketAction
 
     boolean questionSentSuccessfully;
 
+    public StudentSendQuestionAction(IQuestion question)
+    {
+        this.questionToSend = question;
+    }
+
     @Override
     void setUpSocket() throws UnknownHostException, IOException
     {
@@ -58,11 +63,6 @@ public class StudentSendQuestionAction extends SocketAction
             objectOutputStream.close();
         }
 
-    }
-
-    public void setQuestionToSend(IQuestion questionToSend)
-    {
-        this.questionToSend = questionToSend;
     }
 
     public boolean isQuestionSentSuccessfully()

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -10,6 +10,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 
 /**
@@ -19,20 +20,23 @@ public class StudentSendQuestionAction extends SocketAction
 {
     ObjectOutputStream objectOutputStream;
     DataInputStream dataInputStream;
+    private String domain = "localhost";
 
     IQuestion questionToSend;
+    OnQuestionReceivedListener questionReceivedListener;
 
     boolean questionSentSuccessfully;
 
-    public StudentSendQuestionAction(IQuestion question)
+    public StudentSendQuestionAction(IQuestion question, OnQuestionReceivedListener listener)
     {
         this.questionToSend = question;
+        this.questionReceivedListener = listener;
     }
 
     @Override
     void setUpSocket() throws UnknownHostException, IOException
     {
-        socket = new Socket("localhost", QUESTIONS_PORT_NUMBER);
+        socket = new Socket(domain, QUESTIONS_PORT_NUMBER);
         objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
         dataInputStream = new DataInputStream(socket.getInputStream());
     }
@@ -45,6 +49,10 @@ public class StudentSendQuestionAction extends SocketAction
             objectOutputStream.writeObject(questionToSend);
         }
         questionSentSuccessfully = dataInputStream.readBoolean();
+        if(questionSentSuccessfully)
+        {
+            questionReceivedListener.onQuestionSentSuccessfully(domain,QUESTIONS_PORT_NUMBER);
+        }
     }
 
     @Override
@@ -63,10 +71,5 @@ public class StudentSendQuestionAction extends SocketAction
             objectOutputStream.close();
         }
 
-    }
-
-    public boolean isQuestionSentSuccessfully()
-    {
-        return questionSentSuccessfully;
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -1,25 +1,73 @@
 package edu.uco.schambers.classmate.SocketActions;
 
+import android.util.Log;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+
 /**
  * Created by Steven Chambers on 10/3/2015.
  */
 public class StudentSendQuestionAction extends SocketAction
 {
-    @Override
-    void setUpSocket()
-    {
+    Socket socket;
+    ObjectOutputStream objectOutputStream;
+    DataInputStream dataInputStream;
 
+    IQuestion questionToSend;
+
+    boolean questionSentSuccessfully;
+
+    @Override
+    void setUpSocket() throws UnknownHostException, IOException
+    {
+        socket = new Socket("localhost", QUESTIONS_PORT_NUMBER);
+        objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
+        dataInputStream = new DataInputStream(socket.getInputStream());
     }
 
     @Override
-    void performAction()
+    void performAction() throws IOException
     {
-
+        if (questionToSend != null)
+        {
+            objectOutputStream.writeObject(questionToSend);
+        }
+        questionSentSuccessfully = dataInputStream.readBoolean();
     }
 
     @Override
-    void tearDownSocket()
+    void tearDownSocket() throws IOException
     {
+        if(socket != null)
+        {
+            socket.close();
+        }
+        if(dataInputStream != null)
+        {
+            dataInputStream.close();
+        }
+        if(objectOutputStream != null)
+        {
+            objectOutputStream.close();
+        }
 
+    }
+
+    public void setQuestionToSend(IQuestion questionToSend)
+    {
+        this.questionToSend = questionToSend;
+    }
+
+    public boolean isQuestionSentSuccessfully()
+    {
+        return questionSentSuccessfully;
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -17,7 +17,6 @@ import edu.uco.schambers.classmate.Models.Questions.IQuestion;
  */
 public class StudentSendQuestionAction extends SocketAction
 {
-    Socket socket;
     ObjectOutputStream objectOutputStream;
     DataInputStream dataInputStream;
 

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -1,0 +1,25 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public class StudentSendQuestionAction extends SocketAction
+{
+    @Override
+    void setUpSocket()
+    {
+
+    }
+
+    @Override
+    void performAction()
+    {
+
+    }
+
+    @Override
+    void tearDownSocket()
+    {
+
+    }
+}


### PR DESCRIPTION
In this update:
- Question objects are now able to be transmitted by and received by the student question service through java sockets. 
- Once the student question service is started, it sets up a StudentReceiveQuestionAction that runs continuously on another thread waiting for a question to be received on port 8080. When it receives a question, it fires the appropriate notification.
- In order to demonstrate this functionality, one must use connors fragment to launch the initial question. When selecting an answer and pressing the send button, the question is then serialized and sent through a java socket to 'localhoast' back to itself. This causes it to be received by the socket action class in the previous point, redisplaying the question (through the broadcast notification).

@Perrofrijole and @song4u  should for sure have a look at this code as well, portions of it should be reusable for their modules (mainly the SocketAction class).
