### PR TITLE
Wz p2p socket new

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
             android:enabled="true"
             android:exported="true" >
         </service>
+        <service
+            android:name=".Services.StudentRollCallService"
+            android:enabled="true"
+            android:exported="true" >
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -12,6 +12,7 @@ import android.net.Uri;
 import android.net.wifi.WpsInfo;
 import android.net.wifi.p2p.WifiP2pConfig;
 import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pGroup;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.Channel;
 import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceInfo;
@@ -376,5 +377,36 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
         wifiReceiverIntentFilter.addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
 
         registerReceiver(wifiReceiver, wifiReceiverIntentFilter);
+    }
+
+    @Override
+    public void onDestroy() {
+        if (wifiReceiver != null) {
+            unregisterReceiver(wifiReceiver);
+        }
+
+        if (mManager != null && mChannel != null){
+            mManager.requestGroupInfo(mChannel, new WifiP2pManager.GroupInfoListener() {
+                @Override
+                public void onGroupInfoAvailable(WifiP2pGroup group) {
+                    if (group != null) {
+                        mManager.removeGroup(mChannel, new WifiP2pManager.ActionListener() {
+                            @Override
+                            public void onSuccess() {
+                                Log.d("ServiceDiscovery", "Removing Wifi p2p group");
+                            }
+
+                            @Override
+                            public void onFailure(int reason) {
+                                Log.d("ServiceDiscovery", "Failed *Removing Wifi p2p group");
+                            }
+                        });
+                    }
+                }
+            });
+
+        }
+
+        super.onDestroy();
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -3,8 +3,10 @@ package edu.uco.schambers.classmate.Activites;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.net.wifi.WpsInfo;
@@ -26,6 +28,7 @@ import java.util.Map;
 
 
 //import edu.uco.schambers.classmate.BroadcastReceivers.CallForStudentQuestionResponseReceiver;
+import edu.uco.schambers.classmate.BroadcastReceivers.WiFiDirectBroadcastReceiver;
 import edu.uco.schambers.classmate.Fragments.Auth;
 
 import edu.uco.schambers.classmate.Fragments.Debug;
@@ -64,6 +67,9 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
     public static final String SERVICE_FOUND = "edu.uco.schambers.classmate.wifip2p.service_found";
 
     private WifiP2pDevice targetDevice = null;
+
+    // BroadcastReceiver
+    private BroadcastReceiver wifiReceiver;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -356,5 +362,19 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                     }
                 });
 
+    }
+
+    public void setupBroadcastReceiver(WiFiDirectBroadcastReceiver receiver){
+        receiver.setChannel(mChannel);
+        receiver.setManager(mManager);
+        wifiReceiver = receiver;
+
+        IntentFilter wifiReceiverIntentFilter;wifiReceiverIntentFilter = new IntentFilter();
+        wifiReceiverIntentFilter.addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION);
+        wifiReceiverIntentFilter.addAction(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION);
+        wifiReceiverIntentFilter.addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION);
+        wifiReceiverIntentFilter.addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
+
+        registerReceiver(wifiReceiver, wifiReceiverIntentFilter);
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.net.wifi.WpsInfo;
+import android.net.wifi.p2p.WifiP2pConfig;
 import android.net.wifi.p2p.WifiP2pDevice;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.Channel;
@@ -59,6 +61,8 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
 
     // Constants
     public static final String SERVICE_FOUND = "edu.uco.schambers.classmate.wifip2p.service_found";
+
+    private WifiP2pDevice targetDevice = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -318,5 +322,44 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                 Log.d("ServiceRemoval", "Error: " + errorMessage);
             }
         });
+    }
+
+    public void connectToPeer() {
+        if (targetDevice == null){
+            Log.d("ServiceDiscovery", "Target not found, make sure this method is called after a service was found");
+        }
+
+        WifiP2pConfig config = new WifiP2pConfig();
+        config.deviceAddress = targetDevice.deviceAddress;
+        config.wps.setup = WpsInfo.PBC;
+
+        if (serviceRequest != null)
+            mManager.removeServiceRequest(mChannel, serviceRequest,
+                    new WifiP2pManager.ActionListener() {
+
+                        @Override
+                        public void onSuccess() {
+
+                        }
+
+                        @Override
+                        public void onFailure(int arg0) {
+                        }
+                    });
+
+        mManager.connect(mChannel, config,
+                new WifiP2pManager.ActionListener() {
+
+                    @Override
+                    public void onSuccess() {
+                        Log.d("ServiceDiscovery", "Connecting to service");
+                    }
+
+                    @Override
+                    public void onFailure(int errorCode) {
+                        Log.d("ServiceDiscovery", "Failed connecting to service");
+                    }
+                });
+
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -179,6 +179,9 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                 // Command successful! Code isn't necessarily needed here,
                 // Unless you want to update the UI or add logging statements.
                 Log.d("ServiceCreation", "Service creation successful");
+
+                // Create group. This method default the host device as group owner
+                mManager.createGroup(mChannel, null);
             }
 
             @Override

--- a/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Activites/MainActivity.java
@@ -37,6 +37,7 @@ import edu.uco.schambers.classmate.Fragments.TeacherInterface;
 import edu.uco.schambers.classmate.Fragments.TeacherQuestionResults;
 import edu.uco.schambers.classmate.Fragments.UserInformation;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+import edu.uco.schambers.classmate.ObservableManagers.ServiceDiscoveryManager;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.Services.StudentQuestionService;
 
@@ -217,21 +218,12 @@ public class MainActivity extends Activity implements StudentResponseFragment.On
                         // A service has been discovered. Is this our app?
                         if (instanceName.equalsIgnoreCase(SERVICE_INSTANCE)){
 
-                            Intent intent = new Intent(MainActivity.SERVICE_FOUND);
-
-                            // Traverse all the key-value pair that sent from server
-                            // and put them to intent.
-                            for (Map.Entry<String,String> entry : records.entrySet()) {
-                                String key = entry.getKey();
-                                String value = entry.getValue();
-
-                                intent.putExtra(key, value);
-                            }
-
                             // Notify the observers to update their UI
-                            broadcaster.sendBroadcast(intent);
+                            ServiceDiscoveryManager.getInstance().directNotifyObservers(records);
 
                             Log.d("ServiceDiscovery", "Service found");
+
+                            targetDevice = srcDevice;
                         }
 
                     }

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
@@ -1,6 +1,8 @@
 package edu.uco.schambers.classmate.BroadcastReceivers;
 
+import android.app.Activity;
 import android.app.Fragment;
+import android.content.Intent;
 import android.net.NetworkInfo;
 import android.net.wifi.p2p.WifiP2pDevice;
 import android.net.wifi.p2p.WifiP2pDeviceList;
@@ -8,6 +10,8 @@ import android.net.wifi.p2p.WifiP2pInfo;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.util.Log;
 import edu.uco.schambers.classmate.Fragments.StudentRollCall;
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
+import edu.uco.schambers.classmate.Services.StudentRollCallService;
 
 /**
  * Created by WenHsi on 10/6/2015.
@@ -42,8 +46,15 @@ public class StudentRollCallBroadcastReceiver extends WiFiDirectBroadcastReceive
     @Override
     void onPeerConnected(NetworkInfo networkState, WifiP2pInfo wifiInfo, WifiP2pDevice device) {
         if(fragment instanceof StudentRollCall) {
-            Log.d("SocketAction", "Sending Wifi info");
-            ((StudentRollCall) fragment).sendStudentInfoTo(wifiInfo);
+            if (!wifiInfo.isGroupOwner){
+                IPAddressManager.getInstance().setGroupOwnerAddress(wifiInfo.groupOwnerAddress);
+
+                Log.d("SocketAction", "Group owner address has retrieved");
+                Activity activity = fragment.getActivity();
+
+                Intent studentServiceIntent = new Intent(activity, StudentRollCallService.class);
+                activity.startService(studentServiceIntent);
+            }
         }
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
@@ -3,6 +3,7 @@ package edu.uco.schambers.classmate.BroadcastReceivers;
 import android.app.Fragment;
 import android.net.NetworkInfo;
 import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pDeviceList;
 import android.net.wifi.p2p.WifiP2pInfo;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.util.Log;
@@ -34,7 +35,7 @@ public class StudentRollCallBroadcastReceiver extends WiFiDirectBroadcastReceive
     }
 
     @Override
-    void onPeerListChanged() {
+    void onPeerListChanged(WifiP2pDeviceList wifiP2pDeviceList) {
 
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/StudentRollCallBroadcastReceiver.java
@@ -1,0 +1,58 @@
+package edu.uco.schambers.classmate.BroadcastReceivers;
+
+import android.app.Fragment;
+import android.net.NetworkInfo;
+import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pInfo;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.util.Log;
+import edu.uco.schambers.classmate.Fragments.StudentRollCall;
+
+/**
+ * Created by WenHsi on 10/6/2015.
+ */
+public class StudentRollCallBroadcastReceiver extends WiFiDirectBroadcastReceiver {
+
+    public StudentRollCallBroadcastReceiver(){ }
+
+    public StudentRollCallBroadcastReceiver(Fragment fragment) {
+        super(fragment);
+    }
+
+    public StudentRollCallBroadcastReceiver(WifiP2pManager manager, WifiP2pManager.Channel channel,Fragment fragment) {
+        super(manager, channel, fragment);
+    }
+
+    @Override
+    void onWiFiDirectEnabled() {
+
+    }
+
+    @Override
+    void onWiFiDirectDisabled() {
+
+    }
+
+    @Override
+    void onPeerListChanged() {
+
+    }
+
+    @Override
+    void onPeerConnected(NetworkInfo networkState, WifiP2pInfo wifiInfo, WifiP2pDevice device) {
+        if(fragment instanceof StudentRollCall) {
+            Log.d("SocketAction", "Sending Wifi info");
+            ((StudentRollCall) fragment).sendStudentInfoTo(wifiInfo);
+        }
+    }
+
+    @Override
+    void onPeerDisconnected() {
+
+    }
+
+    @Override
+    void onDeviceConfigChanged() {
+
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/WiFiDirectBroadcastReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/WiFiDirectBroadcastReceiver.java
@@ -1,0 +1,99 @@
+package edu.uco.schambers.classmate.BroadcastReceivers;
+
+import android.app.Fragment;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.NetworkInfo;
+import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pInfo;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.util.Log;
+
+/**
+ * Created by WenHsi on 10/6/2015.
+ */
+public abstract class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
+
+    protected WifiP2pManager manager;
+    protected WifiP2pManager.Channel channel;
+    protected Fragment fragment;
+
+    public void setManager(WifiP2pManager manager) {
+        this.manager = manager;
+    }
+
+    public void setChannel(WifiP2pManager.Channel channel) {
+        this.channel = channel;
+    }
+
+    public void setActivity(Fragment fragment) {
+        this.fragment = fragment;
+    }
+
+    public WiFiDirectBroadcastReceiver(){
+        super();
+    }
+
+    public WiFiDirectBroadcastReceiver(Fragment fragment) {
+        super();
+        this.fragment = fragment;
+    }
+
+    public WiFiDirectBroadcastReceiver(WifiP2pManager manager, WifiP2pManager.Channel channel,Fragment fragment) {
+        super();
+        this.manager = manager;
+        this.channel = channel;
+        this.fragment = fragment;
+    }
+
+    abstract void onWiFiDirectEnabled();
+    abstract void onWiFiDirectDisabled();
+    abstract void onPeerListChanged();
+    abstract void onPeerConnected(NetworkInfo networkState, WifiP2pInfo wifiInfo, WifiP2pDevice device);
+    abstract void onPeerDisconnected();
+    abstract void onDeviceConfigChanged();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+
+        if (WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION.equals(action)) {
+            // Check to see if Wi-Fi is enabled and notify appropriate activity
+            int state = intent.getIntExtra(WifiP2pManager.EXTRA_WIFI_STATE, -1);
+
+            if (state == WifiP2pManager.WIFI_P2P_STATE_ENABLED) {
+                onWiFiDirectEnabled();
+            } else {
+                onWiFiDirectDisabled();
+            }
+
+        } else if (WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION.equals(action)) {
+
+            onPeerListChanged();
+
+        } else if (WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION.equals(action)) {
+            final NetworkInfo networkState = intent.getParcelableExtra(WifiP2pManager.EXTRA_NETWORK_INFO);
+            final WifiP2pDevice device = intent.getParcelableExtra(WifiP2pManager.EXTRA_WIFI_P2P_DEVICE);
+
+            if(networkState.isConnected())
+            {
+                Log.d("SocketAction", "Peer is connected");
+
+                manager.requestConnectionInfo(channel, new WifiP2pManager.ConnectionInfoListener() {
+                    @Override
+                    public void onConnectionInfoAvailable(WifiP2pInfo info) {
+                        onPeerConnected(networkState, info, device);
+                    }
+                });
+            }
+            else
+            {
+                onPeerDisconnected();
+            }
+
+        } else if (WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION.equals(action)) {
+            onDeviceConfigChanged();
+        }
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/WiFiDirectBroadcastReceiver.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/BroadcastReceivers/WiFiDirectBroadcastReceiver.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.NetworkInfo;
 import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pDeviceList;
 import android.net.wifi.p2p.WifiP2pInfo;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.util.Log;
@@ -49,7 +50,7 @@ public abstract class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
 
     abstract void onWiFiDirectEnabled();
     abstract void onWiFiDirectDisabled();
-    abstract void onPeerListChanged();
+    abstract void onPeerListChanged(WifiP2pDeviceList wifiP2pDeviceList);
     abstract void onPeerConnected(NetworkInfo networkState, WifiP2pInfo wifiInfo, WifiP2pDevice device);
     abstract void onPeerDisconnected();
     abstract void onDeviceConfigChanged();
@@ -69,8 +70,14 @@ public abstract class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
             }
 
         } else if (WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION.equals(action)) {
+            manager.requestPeers(channel, new WifiP2pManager.PeerListListener() {
+                @Override
+                public void onPeersAvailable(WifiP2pDeviceList peers) {
 
-            onPeerListChanged();
+                    onPeerListChanged(peers);
+                }
+            });
+
 
         } else if (WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION.equals(action)) {
             final NetworkInfo networkState = intent.getParcelableExtra(WifiP2pManager.EXTRA_NETWORK_INFO);

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -36,7 +36,12 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+
 import edu.uco.schambers.classmate.Activites.MainActivity;
+import edu.uco.schambers.classmate.ObservableManagers.ServiceDiscoveryManager;
 import edu.uco.schambers.classmate.R;
 
 /**
@@ -63,7 +68,7 @@ public class StudentRollCall extends Fragment {
 
     private SharedPreferences prefs;
 
-    private BroadcastReceiver receiver;
+    private Observer observer;
 
     private OnFragmentInteractionListener mListener;
 
@@ -102,21 +107,17 @@ public class StudentRollCall extends Fragment {
 
         setHasOptionsMenu(true);
 
-        // Our handler for received Intents. This will be called whenever an Intent
-        // with an action named "service_found" is broadcasted.
-        receiver = new BroadcastReceiver() {
+        observer = new Observer() {
             @Override
-            public void onReceive(Context context, Intent intent) {
+            public void update(Observable observable, Object data) {
+                Map<String, String> record = (Map<String, String>)data;
+
                 btnCheckin.setEnabled(true);
-                lblCheckinStatus.setText("Professor " + intent.getStringExtra("buddyname") + "'s class has been found");
+                lblCheckinStatus.setText("Professor " + record.get("buddyname") + "'s class has been found");
             }
         };
 
-        // Register to receive messages.
-        // We are registering an observer (receiver) to receive Intents
-        // with actions named "service_found".
-        LocalBroadcastManager.getInstance(this.getActivity()).registerReceiver(receiver,
-                new IntentFilter(MainActivity.SERVICE_FOUND));
+        ServiceDiscoveryManager.getInstance().addObserver(observer);
 
         // Discover teacher coll roll service
         discoverService();
@@ -259,7 +260,7 @@ public class StudentRollCall extends Fragment {
     @Override
     public void onDestroy() {
         // Unregister since the fragment is about to be closed.
-        LocalBroadcastManager.getInstance(this.getActivity()).unregisterReceiver(receiver);
+        ServiceDiscoveryManager.getInstance().deleteObserver(observer);
         super.onDestroy();
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -23,6 +23,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.net.wifi.p2p.WifiP2pInfo;
 import android.os.Bundle;
 import android.app.Fragment;
 import android.support.v4.content.LocalBroadcastManager;
@@ -43,6 +44,7 @@ import java.util.Observer;
 import edu.uco.schambers.classmate.Activites.MainActivity;
 import edu.uco.schambers.classmate.ObservableManagers.ServiceDiscoveryManager;
 import edu.uco.schambers.classmate.R;
+import edu.uco.schambers.classmate.Services.StudentRollCallService;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -259,6 +261,13 @@ public class StudentRollCall extends Fragment {
         if(activity instanceof MainActivity) {
             ((MainActivity) activity).connectToPeer();
         }
+    }
+
+    public void sendStudentInfoTo(WifiP2pInfo wifiInfo){
+        Intent studentServiceIntent = new Intent(this.getActivity(), StudentRollCallService.class);
+        studentServiceIntent.putExtra("wifiInfo", wifiInfo);
+
+        getActivity().startService(studentServiceIntent);
     }
 
     // TODO: Rename method, update argument and hook method into UI event

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -42,6 +42,7 @@ import java.util.Observable;
 import java.util.Observer;
 
 import edu.uco.schambers.classmate.Activites.MainActivity;
+import edu.uco.schambers.classmate.BroadcastReceivers.StudentRollCallBroadcastReceiver;
 import edu.uco.schambers.classmate.ObservableManagers.ServiceDiscoveryManager;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.Services.StudentRollCallService;
@@ -108,6 +109,8 @@ public class StudentRollCall extends Fragment {
         prefs = this.getActivity().getSharedPreferences("studentRollCallPrefs", Context.MODE_PRIVATE);
 
         setHasOptionsMenu(true);
+
+        initBroadcast();
 
         observer = new Observer() {
             @Override
@@ -268,6 +271,15 @@ public class StudentRollCall extends Fragment {
         studentServiceIntent.putExtra("wifiInfo", wifiInfo);
 
         getActivity().startService(studentServiceIntent);
+    }
+
+    private void initBroadcast(){
+        Activity activity = getActivity();
+
+        /// Start discovering teacher service
+        if(activity instanceof MainActivity) {
+            ((MainActivity) activity).setupBroadcastReceiver(new StudentRollCallBroadcastReceiver(this));
+        }
     }
 
     // TODO: Rename method, update argument and hook method into UI event

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -209,6 +209,8 @@ public class StudentRollCall extends Fragment {
                 changeAudioSetting(prefs.getString("CheckedInMode", null));
 
                 lblCheckinStatus.setText(getString(R.string.lbl_status_checked_in));
+
+                connectToGroupOwner();
                 Toast.makeText(getActivity(), "You've checked-in", Toast.LENGTH_SHORT).show();
             }
         });
@@ -247,6 +249,15 @@ public class StudentRollCall extends Fragment {
         /// Start discovering teacher service
         if(activity instanceof MainActivity) {
             ((MainActivity) activity).discoverLocalService();
+        }
+    }
+
+    private void connectToGroupOwner(){
+        Activity activity = getActivity();
+
+        /// Start discovering teacher service
+        if(activity instanceof MainActivity) {
+            ((MainActivity) activity).connectToPeer();
         }
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentRollCall.java
@@ -266,13 +266,6 @@ public class StudentRollCall extends Fragment {
         }
     }
 
-    public void sendStudentInfoTo(WifiP2pInfo wifiInfo){
-        Intent studentServiceIntent = new Intent(this.getActivity(), StudentRollCallService.class);
-        studentServiceIntent.putExtra("wifiInfo", wifiInfo);
-
-        getActivity().startService(studentServiceIntent);
-    }
-
     private void initBroadcast(){
         Activity activity = getActivity();
 

--- a/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/IPAddressManager.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/IPAddressManager.java
@@ -1,0 +1,42 @@
+package edu.uco.schambers.classmate.ObservableManagers;
+
+import java.net.InetAddress;
+import java.util.Observable;
+
+/**
+ * Author: Wenxi Zeng
+ * Purpose:
+ *   Use singleton pattern to hold a reference of groupOwnerAddress.
+ *   This class is also observable.
+ *   If you want to get a notification of group owner address changes,
+ *   you'll need to add a observer to it.
+ *   Otherwise, there is no extra work to get the group owner address.
+ */
+public class IPAddressManager extends Observable{
+
+    private InetAddress groupOwnerAddress;
+    private static volatile IPAddressManager instance = null;
+    private IPAddressManager() { }
+
+    public InetAddress getGroupOwnerAddress() {
+        return groupOwnerAddress;
+    }
+
+    public void setGroupOwnerAddress(InetAddress groupOwnerAddress) {
+        this.groupOwnerAddress = groupOwnerAddress;
+        directNotifyObservers(this.groupOwnerAddress);
+    }
+
+    public static synchronized IPAddressManager getInstance() {
+        if (instance == null) {
+            instance = new IPAddressManager();
+        }
+
+        return instance;
+    }
+
+    public void directNotifyObservers(Object data){
+        instance.setChanged();
+        instance.notifyObservers(data);
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/ServiceDiscoveryManager.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/ServiceDiscoveryManager.java
@@ -1,0 +1,25 @@
+package edu.uco.schambers.classmate.ObservableManagers;
+
+import java.util.Observable;
+
+/**
+ * Created by WenHsi on 10/5/2015.
+ */
+public class ServiceDiscoveryManager extends Observable {
+
+    private static volatile ServiceDiscoveryManager instance = null;
+    private ServiceDiscoveryManager() { }
+
+    public static synchronized ServiceDiscoveryManager getInstance() {
+        if (instance == null) {
+            instance = new ServiceDiscoveryManager();
+        }
+
+        return instance;
+    }
+
+    public void directNotifyObservers(Object data){
+        instance.setChanged();
+        instance.notifyObservers(data);
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
@@ -1,0 +1,49 @@
+package edu.uco.schambers.classmate.Services;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.net.wifi.p2p.WifiP2pInfo;
+import android.util.Log;
+
+import java.net.InetAddress;
+
+import edu.uco.schambers.classmate.SocketActions.SocketAction;
+import edu.uco.schambers.classmate.SocketActions.StudentRollCallAction;
+
+/**
+ * Created by WenHsi on 10/6/2015.
+ */
+public class StudentRollCallService extends IntentService {
+
+    private WifiP2pInfo wifiInfo;
+    private SocketAction socketAction;
+
+    public StudentRollCallService() {
+        super("StudentRollCallService");
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        wifiInfo = (WifiP2pInfo) intent.getExtras().get("wifiInfo");
+
+        Log.d("SocketAction", "Handling in Service");
+
+        if(!wifiInfo.isGroupOwner){
+            socketAction = new StudentRollCallAction();
+
+            InetAddress targetIP = wifiInfo.groupOwnerAddress;
+            socketAction.setTargetIP(targetIP);
+
+            Log.d("SocketAction", "Target is group owner");
+            socketAction.execute();
+        }
+    }
+
+    @Override
+    public void onDestroy()
+    {
+        //Signal that the service was stopped
+        //serverResult.send(port, new Bundle());
+        stopSelf();
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
@@ -24,17 +24,10 @@ public class StudentRollCallService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
+        socketAction = new StudentRollCallAction();
 
-        InetAddress targetIP = IPAddressManager.getInstance().getGroupOwnerAddress();
-        Log.d("SocketAction", "Handling in Service");
-
-        if(targetIP != null){
-            socketAction = new StudentRollCallAction();
-            socketAction.setTargetIP(targetIP);
-
-            Log.d("SocketAction", "Target is group owner");
-            socketAction.execute();
-        }
+        Log.d("SocketAction", "Target is group owner");
+        socketAction.execute();
     }
 
     @Override

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentRollCallService.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import java.net.InetAddress;
 
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 import edu.uco.schambers.classmate.SocketActions.SocketAction;
 import edu.uco.schambers.classmate.SocketActions.StudentRollCallAction;
 
@@ -15,7 +16,6 @@ import edu.uco.schambers.classmate.SocketActions.StudentRollCallAction;
  */
 public class StudentRollCallService extends IntentService {
 
-    private WifiP2pInfo wifiInfo;
     private SocketAction socketAction;
 
     public StudentRollCallService() {
@@ -24,14 +24,12 @@ public class StudentRollCallService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-        wifiInfo = (WifiP2pInfo) intent.getExtras().get("wifiInfo");
 
+        InetAddress targetIP = IPAddressManager.getInstance().getGroupOwnerAddress();
         Log.d("SocketAction", "Handling in Service");
 
-        if(!wifiInfo.isGroupOwner){
+        if(targetIP != null){
             socketAction = new StudentRollCallAction();
-
-            InetAddress targetIP = wifiInfo.groupOwnerAddress;
             socketAction.setTargetIP(targetIP);
 
             Log.d("SocketAction", "Target is group owner");

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -26,17 +26,8 @@ public abstract class SocketAction
 {
    public static final int ROLL_CALL_PORT_NUMBER = 4001;
    public static final int QUESTIONS_PORT_NUMBER = 4002;
-
-   protected InetAddress targetIP;
+   
    Socket socket;
-
-   public InetAddress getTargetIP() {
-      return targetIP;
-   }
-
-   public void setTargetIP(InetAddress targetIP) {
-      this.targetIP = targetIP;
-   }
 
    abstract void setUpSocket() throws  IOException;
    abstract void performAction() throws IOException;

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -18,6 +18,7 @@ import android.util.Log;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
@@ -26,7 +27,16 @@ public abstract class SocketAction
    public static final int ROLL_CALL_PORT_NUMBER = 4001;
    public static final int QUESTIONS_PORT_NUMBER = 4002;
 
+   protected InetAddress targetIP;
    Socket socket;
+
+   public InetAddress getTargetIP() {
+      return targetIP;
+   }
+
+   public void setTargetIP(InetAddress targetIP) {
+      this.targetIP = targetIP;
+   }
 
    abstract void setUpSocket() throws  IOException;
    abstract void performAction() throws IOException;

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentRollCallAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentRollCallAction.java
@@ -6,7 +6,10 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.Socket;
+
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 
 /**
  * Created by WenHsi on 10/6/2015.
@@ -20,10 +23,16 @@ public class StudentRollCallAction extends SocketAction {
 
     @Override
     void setUpSocket() throws IOException {
+        InetAddress targetIP = IPAddressManager.getInstance().getGroupOwnerAddress();
 
-        socket = new Socket(targetIP, ROLL_CALL_PORT_NUMBER);
-        objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
-        dataInputStream = new DataInputStream(socket.getInputStream());
+        if(targetIP != null) {
+            socket = new Socket(targetIP, ROLL_CALL_PORT_NUMBER);
+            objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
+            dataInputStream = new DataInputStream(socket.getInputStream());
+        }
+        else {
+            Log.d("SocketAction", "Group owner address not found, check your connection");
+        }
     }
 
     @Override

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentRollCallAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentRollCallAction.java
@@ -1,0 +1,54 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+import android.util.Log;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+/**
+ * Created by WenHsi on 10/6/2015.
+ */
+public class StudentRollCallAction extends SocketAction {
+
+    ObjectOutputStream objectOutputStream;
+    DataInputStream dataInputStream;
+
+    private boolean result = false;
+
+    @Override
+    void setUpSocket() throws IOException {
+
+        socket = new Socket(targetIP, ROLL_CALL_PORT_NUMBER);
+        objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
+        dataInputStream = new DataInputStream(socket.getInputStream());
+    }
+
+    @Override
+    void performAction() throws IOException {
+        Log.d("SocketAction", "Sending message to server");
+
+        objectOutputStream.writeObject("Test message for student roll call");
+        result = dataInputStream.readBoolean();
+
+        Log.d("SocketAction", String.valueOf(result));
+    }
+
+    @Override
+    void tearDownSocket() throws IOException {
+        if(socket != null)
+        {
+            socket.close();
+        }
+        if(dataInputStream != null)
+        {
+            dataInputStream.close();
+        }
+        if(objectOutputStream != null)
+        {
+            objectOutputStream.close();
+        }
+    }
+}


### PR DESCRIPTION
Fully tested with sending message through socket connection. For testing this feature, run student and teacher roll call in different devices (Teacher roll call requires to login), and track catlog tag "SocketAction". The student catlogs show the processing of sending message through socket. In order to see the sent message on teacher side, you will need to add Log.d to output the string on TeacherRollCallAction class.

Known issues:
- The call roll service sometimes cannot be discovered.
  The app will be crashed if sends a message when the wifi p2p connection is busy. (Will visit back for handling this exception on next commit).
- The app crashes if the app is closed without remove the local service. 

Changes:
- Replace BroadcastReceiver with Observer pattern to update UI when a service is found. I tried to use OnFragmentInteractionListener, but it brings some code related to StudentCallRoll and makes the MainActivity messy.
- Made p2p connection between GroupOwner and Clients.
- Implement StudentRollCallAction by Extending SocketAction.
- Create an abstract WiFiDirectBroadcastReceiver for handling p2p connection changes.
- Add StudentRollCallService. This service calls SocketAction.execute() to send out message
- Add variables of target ip address and roll call port to SocketAction
- Add createGroup method to addLocalService() in MainActivity. The device which calls addLocalService() is defaulted as group owner.
