### PR TITLE
Add Teacher Service and Corresponding Socket Actions

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/Debug.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/Debug.java
@@ -131,7 +131,7 @@ public class Debug extends Fragment
             @Override
             public void onClick(View v)
             {
-                Fragment teacherQuestion = TeacherQuestion.newInstance("test", "test");
+                Fragment teacherQuestion = TeacherQuestion.newInstance(null);
                 launchFragment(teacherQuestion);
             }
         });

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherInterface.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherInterface.java
@@ -115,7 +115,7 @@ public class TeacherInterface extends Fragment {
             public void onClick(View v)
             {
 
-                Fragment teacherQuestion = TeacherQuestion.newInstance("test", "test");
+                Fragment teacherQuestion = TeacherQuestion.newInstance(null);
                 launchFragment(teacherQuestion);
 
             }

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
@@ -14,6 +14,7 @@ import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.Services.StudentQuestionService;
+import edu.uco.schambers.classmate.Services.TeacherQuestionService;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -26,12 +27,10 @@ import edu.uco.schambers.classmate.Services.StudentQuestionService;
 public class TeacherQuestion extends Fragment {
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-    private static final String ARG_PARAM1 = "param1";
-    private static final String ARG_PARAM2 = "param2";
+    public static final String ARG_QUESTION = "edu.uco.schambers.classmate.arq_question";
 
     // TODO: Rename and change types of parameters
-    private String mParam1;
-    private String mParam2;
+    private IQuestion question;
 
     private Button toggleBtn;
 
@@ -44,16 +43,13 @@ public class TeacherQuestion extends Fragment {
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
      *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
      * @return A new instance of fragment TeacherQuestion.
      */
     // TODO: Rename and change types and number of parameters
-    public static TeacherQuestion newInstance(String param1, String param2) {
+    public static TeacherQuestion newInstance(IQuestion question) {
         TeacherQuestion fragment = new TeacherQuestion();
         Bundle args = new Bundle();
-        args.putString(ARG_PARAM1, param1);
-        args.putString(ARG_PARAM2, param2);
+        args.putSerializable(ARG_QUESTION, question);
         fragment.setArguments(args);
         return fragment;
     }
@@ -66,8 +62,7 @@ public class TeacherQuestion extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
-            mParam1 = getArguments().getString(ARG_PARAM1);
-            mParam2 = getArguments().getString(ARG_PARAM2);
+            question = (IQuestion) getArguments().getSerializable(ARG_QUESTION);
         }
     }
 
@@ -101,11 +96,15 @@ public class TeacherQuestion extends Fragment {
 
     }
 
+    //Call to service ****CURRENT****
     private void sendQuestion(){
         //TODO implement sendQuestion method
         IQuestion question = new DefaultMultiChoiceQuestion();
-        Intent intent = StudentQuestionService.getNewSendQuestionIntent(getActivity(), question);
+        Intent intent = TeacherQuestionService.getNewSendQuestionIntent(getActivity(), question);
+        Intent intent1 = StudentQuestionService.getNewSendResponseIntent(getActivity(), question);
+        //TODO create teacherQuestion service and initialize for communication w/ steven
         getActivity().startService(intent);
+        getActivity().startService(intent1);
         //stub toast
         Toast.makeText(getActivity(), "Question sent to class!", Toast.LENGTH_SHORT).show();
     }
@@ -129,7 +128,7 @@ public class TeacherQuestion extends Fragment {
      */
     public interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
-        public void onFragmentInteraction(Uri uri);
+        void onFragmentInteraction(Uri uri);
     }
 
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
@@ -145,7 +145,7 @@ public class TeacherQuestionService extends Service implements OnQuestionReceive
 
             public void run()
             {
-                Toast.makeText(getBaseContext(),String.format("The question was sent successfully by the teacher to domain: %s port %d ", domainFinal, portFinal), Toast.LENGTH_LONG).show();
+                Toast.makeText(getBaseContext(),String.format("The question was sent successfully to domain: %s port %d ", domainFinal, portFinal), Toast.LENGTH_LONG).show();
             }
         });
     }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
@@ -1,0 +1,152 @@
+package edu.uco.schambers.classmate.Services;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.support.v4.app.NotificationCompat;
+import android.widget.Toast;
+
+import edu.uco.schambers.classmate.Activites.MainActivity;
+import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
+import edu.uco.schambers.classmate.Fragments.TeacherQuestion;
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+import edu.uco.schambers.classmate.R;
+import edu.uco.schambers.classmate.SocketActions.SocketAction;
+import edu.uco.schambers.classmate.SocketActions.StudentReceiveQuestionsAction;
+import edu.uco.schambers.classmate.SocketActions.StudentSendQuestionAction;
+import edu.uco.schambers.classmate.SocketActions.TeacherReceiveQuestionsAction;
+import edu.uco.schambers.classmate.SocketActions.TeacherSendQuestionAction;
+
+public class TeacherQuestionService extends Service implements OnQuestionReceivedListener
+{
+    public static final String ACTION_NOTIFY_QUESTION_RECEIVED = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_NOTIFY_QUESTION_RECEIVED";
+    public static final String ACTION_REQUEST_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_REQUEST_QUESTION_RESPONSE";
+    public static final String ACTION_SEND_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_SEND_QUESTION_RESPONSE";
+
+    private SocketAction listenForQuestions;
+
+    Handler handler;
+
+    public TeacherQuestionService()
+    {
+    }
+
+    public static Intent getNewSendQuestionIntent(Context context, IQuestion question)
+    {
+        Intent questionReceivedIntent = getBaseIntent(context,question);
+        questionReceivedIntent.setAction(ACTION_NOTIFY_QUESTION_RECEIVED);
+        return questionReceivedIntent;
+    }
+
+    public static Intent getNewSendResponseIntent(Context context, IQuestion question)
+    {
+        Intent questionResponseIntent = getBaseIntent(context,question);
+        questionResponseIntent.setAction(ACTION_SEND_QUESTION_RESPONSE);
+        return questionResponseIntent;
+    }
+
+    private static Intent getBaseIntent(Context context, IQuestion question)
+    {
+        Intent baseQuestionIntent= new Intent(context, TeacherQuestionService.class);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(TeacherQuestion.ARG_QUESTION, question);
+        baseQuestionIntent.putExtras(bundle);
+        return baseQuestionIntent;
+    }
+
+    @Override
+    public void onCreate()
+    {
+        super.onCreate();
+        handler = new Handler(Looper.getMainLooper());
+        //Todo CARCHER TQS.onCreate() -> SRQA Listener
+        listenForQuestions = new TeacherReceiveQuestionsAction(this);
+        listenForQuestions.execute();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId)
+    {
+        String action = intent.getAction();
+        IQuestion question;
+        switch (action)
+        {
+            case ACTION_NOTIFY_QUESTION_RECEIVED:
+                question = (IQuestion) intent.getExtras().getSerializable(TeacherQuestion.ARG_QUESTION);
+                notifyQuestionReceived(question);
+                break;
+            case ACTION_SEND_QUESTION_RESPONSE:
+                question = (IQuestion) intent.getExtras().getSerializable(TeacherQuestion.ARG_QUESTION);
+                sendQuestionResponse(question);
+                break;
+        }
+        return START_STICKY;
+    }
+
+    private void sendQuestionResponse(IQuestion question)
+    {
+        //Todo CARCHER TQS.sendQuestionResponse() -> SocketAction StudentSQA
+        SocketAction sendQuestion = new TeacherSendQuestionAction(question, this);
+        sendQuestion.execute();
+    }
+
+    private void notifyQuestionReceived(IQuestion question)
+    {
+        NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this);
+        notificationBuilder.setSmallIcon(R.drawable.ic_stat_question_broadcast_recieved)
+                .setContentTitle("Question Received")
+                .setContentText("Questions Received! Press here to see class aggregate answers!");
+        notificationBuilder.setAutoCancel(true);
+        notificationBuilder.setPriority(Notification.PRIORITY_HIGH);
+
+        Intent notifyIntent = new Intent(this, MainActivity.class);
+        notifyIntent.setAction(ACTION_REQUEST_QUESTION_RESPONSE);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(TeacherQuestion.ARG_QUESTION, question);
+        notifyIntent.putExtras(bundle);
+        PendingIntent notifyPendingIntent = PendingIntent.getActivity(this, 0, notifyIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        notificationBuilder.setContentIntent(notifyPendingIntent);
+
+        notificationManager.notify(R.integer.question_received_notification, notificationBuilder.build());
+    }
+
+    @Override
+    public IBinder onBind(Intent intent)
+    {
+        // TODO: Return the communication channel to the service.
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void onQuestionReceived(IQuestion question)
+    {
+        Intent intent = getNewSendQuestionIntent(this, question);
+        startService(intent);
+    }
+
+    @Override
+    public void onQuestionSentSuccessfully(String domain, int port)
+    {
+        final String domainFinal = domain;
+        final int portFinal = port;
+        //Yes, I know this is totally awful. Its not going to stay this way, I swear. Just want these toasts to fire for debug purposes.
+        handler.post(new Runnable()
+        {
+            @Override
+
+            public void run()
+            {
+                Toast.makeText(getBaseContext(),String.format("The question was sent successfully by the teacher to domain: %s port %d ", domainFinal, portFinal), Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/SocketAction.java
@@ -18,7 +18,6 @@ import android.util.Log;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
@@ -26,7 +25,7 @@ public abstract class SocketAction
 {
    public static final int ROLL_CALL_PORT_NUMBER = 4001;
    public static final int QUESTIONS_PORT_NUMBER = 4002;
-   
+
    Socket socket;
 
    abstract void setUpSocket() throws  IOException;

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherReceiveQuestionsAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherReceiveQuestionsAction.java
@@ -1,0 +1,88 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+import android.util.Log;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.ServerSocket;
+
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public class TeacherReceiveQuestionsAction extends SocketAction
+{
+    ObjectInputStream objectInputStream;
+    DataOutputStream dataOutputStream;
+    ServerSocket serverSocket;
+
+    OnQuestionReceivedListener questionReceivedListener;
+
+    boolean listeningForQuestions = true;
+    boolean questionReceivedSuccessfully;
+
+    public TeacherReceiveQuestionsAction(OnQuestionReceivedListener listener)
+    {
+       this.questionReceivedListener = listener;
+    }
+
+    @Override
+    void setUpSocket() throws IOException
+    {
+        serverSocket = new ServerSocket(QUESTIONS_PORT_NUMBER);
+
+    }
+
+    @Override
+    void performAction() throws IOException
+    {
+        while (listeningForQuestions)
+        {
+            socket = serverSocket.accept();
+            objectInputStream = new ObjectInputStream(socket.getInputStream());
+            dataOutputStream = new DataOutputStream(socket.getOutputStream());
+
+            try
+            {
+                IQuestion questionReceived =(IQuestion) objectInputStream.readObject();
+                questionReceivedSuccessfully = true;
+                questionReceivedListener.onQuestionReceived(questionReceived);
+            }
+            catch (ClassNotFoundException e)
+            {
+                Log.d("SocketAction", "There was a problem decoding the serializable question. Exception: " + e.toString());
+            }
+            dataOutputStream.writeBoolean(questionReceivedSuccessfully);
+
+        }
+
+    }
+
+    @Override
+    void tearDownSocket() throws IOException
+    {
+        if(serverSocket != null)
+        {
+            serverSocket.close();
+        }
+        if(socket != null)
+        {
+            socket.close();
+        }
+        if(objectInputStream != null)
+        {
+            objectInputStream.close();
+        }
+        if(dataOutputStream != null)
+        {
+            dataOutputStream.close();
+        }
+    }
+    public void stopListening()
+    {
+        listeningForQuestions = false;
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherSendQuestionAction.java
@@ -1,0 +1,71 @@
+package edu.uco.schambers.classmate.SocketActions;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+
+/**
+ * Created by Steven Chambers on 10/3/2015.
+ */
+public class TeacherSendQuestionAction extends SocketAction
+{
+    ObjectOutputStream objectOutputStream;
+    DataInputStream dataInputStream;
+    private String domain = "localhost";
+
+    IQuestion questionToSend;
+    OnQuestionReceivedListener questionReceivedListener;
+
+    boolean questionSentSuccessfully;
+
+    public TeacherSendQuestionAction(IQuestion question, OnQuestionReceivedListener listener)
+    {
+        this.questionToSend = question;
+        this.questionReceivedListener = listener;
+    }
+
+    @Override
+    void setUpSocket() throws UnknownHostException, IOException
+    {
+        socket = new Socket(domain, QUESTIONS_PORT_NUMBER);
+        objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
+        dataInputStream = new DataInputStream(socket.getInputStream());
+    }
+
+    @Override
+    void performAction() throws IOException
+    {
+        if (questionToSend != null)
+        {
+            objectOutputStream.writeObject(questionToSend);
+        }
+        questionSentSuccessfully = dataInputStream.readBoolean();
+        if(questionSentSuccessfully)
+        {
+            questionReceivedListener.onQuestionSentSuccessfully(domain,QUESTIONS_PORT_NUMBER);
+        }
+    }
+
+    @Override
+    void tearDownSocket() throws IOException
+    {
+        if(socket != null)
+        {
+            socket.close();
+        }
+        if(dataInputStream != null)
+        {
+            dataInputStream.close();
+        }
+        if(objectOutputStream != null)
+        {
+            objectOutputStream.close();
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request adds the TeacherQuestionService to handle communication with Steven's StudentQuestionService and facilitate communication and transportation of the IQuestion object to the Student service and then receive the answer back from the student's device. It implements the corresponding sockets mirroring Steven's functinality: TeacherSendQuestionAction and TeacherAcceptQuestionAction. These and the service implement the predefined interfaces established by both Steven and Cole as well as following the Template for a SocketAction.
