### PR TITLE
enable student device to send question back to teachers device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,10 @@
             android:enabled="true"
             android:exported="true" >
         </service>
+        <service android:name=".Services.TeacherQuestionService"
+                 android:enabled="true"
+                 android:exported="true"
+                 />
     </application>
 
 </manifest>

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/Auth.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/Auth.java
@@ -135,7 +135,7 @@ public class Auth extends Fragment {
         dr = new DataRepo(getActivity());
         sp = getActivity().getSharedPreferences(MyPREFS, Context.MODE_PRIVATE);
 
-        if(sp.contains("AUTH_TOKEN") && (!sp.getString("AUTH_TOKEN", null).equals(""))) {
+        if(sp.contains("AUTH_TOKEN") && (!sp.getString("AUTH_TOKEN", "").equals(""))) {
             token = sp.getString("AUTH_TOKEN", null);
             try {
                 User user = TokenUtility.parseUserToken(token);

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -20,6 +20,7 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.Services.StudentQuestionService;
@@ -77,6 +78,14 @@ public class StudentResponseFragment extends Fragment
             initUI(questionCardView);
             populateQuestionCardFromQuestion();
 
+        }
+        //inserting a question for testing
+        else
+        {
+            question = new DefaultMultiChoiceQuestion();
+            questionCardView = inflater.inflate(R.layout.question_response_card, (ViewGroup) rootView);
+            initUI(questionCardView);
+            populateQuestionCardFromQuestion();
         }
         return rootView;
     }

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
@@ -101,10 +101,8 @@ public class TeacherQuestion extends Fragment {
         //TODO implement sendQuestion method
         IQuestion question = new DefaultMultiChoiceQuestion();
         Intent intent = TeacherQuestionService.getNewSendQuestionIntent(getActivity(), question);
-        Intent intent1 = StudentQuestionService.getNewSendResponseIntent(getActivity(), question);
         //TODO create teacherQuestion service and initialize for communication w/ steven
         getActivity().startService(intent);
-        getActivity().startService(intent1);
         //stub toast
         Toast.makeText(getActivity(), "Question sent to class!", Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -12,6 +12,7 @@ import java.net.UnknownHostException;
 
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 
 /**
  * Created by Steven Chambers on 10/3/2015.
@@ -20,7 +21,7 @@ public class StudentSendQuestionAction extends SocketAction
 {
     ObjectOutputStream objectOutputStream;
     DataInputStream dataInputStream;
-    private String domain = "localhost";
+    private String domain = IPAddressManager.getInstance().getGroupOwnerAddress().getHostAddress();
 
     IQuestion questionToSend;
     OnQuestionReceivedListener questionReceivedListener;


### PR DESCRIPTION
Student devices can now return a question back to the teacher via inter device communication.
## Testing

One phone must be logged into a student account and the other must be logged into a teacher account.

Steps I took while testing are as follows:
1. On teacher phone, start roll call.
2. On student phone, go to roll call and check in.
3. On teacher phone, go to in class response and press the send button once, and clear the notification. (this step is needed in order to start @Perrofrijole's service, we will eventually be having our services start up on log in in a future update. We clear the notification so that, of course, we can see when the new question comes in.)
4. On student phone go to in class response, select an answer for the question, and press send.
5. Check the teachers device for a notification, it should be there.
6. The student device will notify the IP and port sent to when the ack is sent back to the student device. 

One issue that I ran into while testing is that, a few times, when trying to leave @song4u's fragment after checking in, I would get a crash from an exception. The exception would be saying something about trying to call the getResources object on a null reference. I assume this is happening because he might have some operation trying to be carried out after his fragment has been detached from the main activity. @song4u, I'm not sure if this is one of the known issue in you mentioned in your most recent pull request or not, so I thought it would be safest to mention it. Let me know if this is the case.
