### PR TITLE
Student IP addresses are tracked

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnStudentConnectListener.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnStudentConnectListener.java
@@ -7,8 +7,8 @@
  *   with the TeacherRollCallService and inform it that a student has
  *   connected
  *
- * Edit: 10/7/2015
- *   Created onStudentConnect method
+ * Edit: 10/12/2015
+ *   Updated onStudentConnect method to gather student IP
  *
  */
 

--- a/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnStudentConnectListener.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnStudentConnectListener.java
@@ -14,7 +14,9 @@
 
 package edu.uco.schambers.classmate.ListenerInterfaces;
 
+import java.net.InetAddress;
+
 public interface OnStudentConnectListener {
     // TODO: use Student object (check with someone on status, may do myself)
-    void onStudentConnect(String id);
+    void onStudentConnect(String id, InetAddress ip);
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/IPAddressManager.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ObservableManagers/IPAddressManager.java
@@ -1,6 +1,7 @@
 package edu.uco.schambers.classmate.ObservableManagers;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Observable;
 
 /**
@@ -11,20 +12,31 @@ import java.util.Observable;
  *   If you want to get a notification of group owner address changes,
  *   you'll need to add a observer to it.
  *   Otherwise, there is no extra work to get the group owner address.
+ *
+ * Edit: 10/12/2015
+ *   Added Student IPs list for use by the teacher
  */
 public class IPAddressManager extends Observable{
 
     private InetAddress groupOwnerAddress;
+    private ArrayList<InetAddress> studentAddresses = new ArrayList<InetAddress>();
     private static volatile IPAddressManager instance = null;
     private IPAddressManager() { }
 
-    public InetAddress getGroupOwnerAddress() {
-        return groupOwnerAddress;
+    public InetAddress getGroupOwnerAddress() { return groupOwnerAddress; }
+    public ArrayList<InetAddress> getStudentAddresses() {
+        return studentAddresses;
     }
 
     public void setGroupOwnerAddress(InetAddress groupOwnerAddress) {
         this.groupOwnerAddress = groupOwnerAddress;
         directNotifyObservers(this.groupOwnerAddress);
+    }
+
+    public void addStudentAddress(InetAddress studentAddress){
+        if(studentAddress != null){
+            studentAddresses.add(studentAddress);
+        }
     }
 
     public static synchronized IPAddressManager getInstance() {

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherRollCallService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherRollCallService.java
@@ -23,6 +23,9 @@ import android.os.Looper;
 import android.util.Log;
 import android.widget.Toast;
 
+import java.net.InetAddress;
+import java.util.ArrayList;
+
 import edu.uco.schambers.classmate.Fragments.TeacherRollCall;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnStudentConnectListener;
 import edu.uco.schambers.classmate.SocketActions.SocketAction;
@@ -32,8 +35,12 @@ import edu.uco.schambers.classmate.SocketActions.TeacherRollCallAction;
 public class TeacherRollCallService extends Service implements OnStudentConnectListener{
     public static final String ACTION_END_ROLL_CALL_SESSION = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_END_ROLL_CALL_SESSION";
     public static final String ACTION_START_ROLL_CALL_SESSION = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_START_ROLL_CALL_SESSION";
+    public static final String ACTION_GET_STUDENT_IPS = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_GET_STUDENT_IPS";
+
 
     private SocketAction listenForStudents;
+
+    private ArrayList<InetAddress> studentIPs = new ArrayList<InetAddress>();
 
     Handler handler;
 
@@ -64,6 +71,10 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
         return baseRollCallIntent;
     }
 
+    public ArrayList<InetAddress> getStudentIPs(){
+        return studentIPs;
+    }
+
     @Override
     public void onCreate()
     {
@@ -90,6 +101,9 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
                 currentTeacher = (String) intent.getExtras().getSerializable(TeacherRollCall.ARG_TEACHER);
                 Toast.makeText(getApplicationContext(),"Class Session Started",Toast.LENGTH_LONG).show();
                 break;
+            //case ACTION_GET_STUDENT_IPS:
+            //
+            //    break;
         }
         return START_STICKY;
     }
@@ -101,8 +115,12 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
     }
 
     @Override
-    public void onStudentConnect(String id) {
+    public void onStudentConnect(String id, InetAddress ip) {
         // TODO: add student ID to ArrayList (possibly query from DB)
         Log.d("StudentConnect", "Connected ID: " + id);
+        if (ip!=null){
+            studentIPs.add(ip);
+            Log.d("StudentConnect", "IP Added: "+ip.toString());
+        }
     }
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherRollCallService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherRollCallService.java
@@ -5,9 +5,8 @@
  *   Background Service for managing the classroom session
  *   Main function is to monitor Students attendance during class
  *
- * Edit: 10/7/2015
- *   Setup Class with Start and End intents for
- *    starting service and stopping SocketAction
+ * Edit: 10/12/2015
+ *   Updated onStudentConnect method to gather student IP
  *
  */
 
@@ -28,6 +27,7 @@ import java.util.ArrayList;
 
 import edu.uco.schambers.classmate.Fragments.TeacherRollCall;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnStudentConnectListener;
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 import edu.uco.schambers.classmate.SocketActions.SocketAction;
 import edu.uco.schambers.classmate.SocketActions.StudentReceiveQuestionsAction;
 import edu.uco.schambers.classmate.SocketActions.TeacherRollCallAction;
@@ -35,12 +35,9 @@ import edu.uco.schambers.classmate.SocketActions.TeacherRollCallAction;
 public class TeacherRollCallService extends Service implements OnStudentConnectListener{
     public static final String ACTION_END_ROLL_CALL_SESSION = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_END_ROLL_CALL_SESSION";
     public static final String ACTION_START_ROLL_CALL_SESSION = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_START_ROLL_CALL_SESSION";
-    public static final String ACTION_GET_STUDENT_IPS = "edu.uco.schambers.classmate.Services.StudentQuestionService.ACTION_GET_STUDENT_IPS";
 
 
     private SocketAction listenForStudents;
-
-    private ArrayList<InetAddress> studentIPs = new ArrayList<InetAddress>();
 
     Handler handler;
 
@@ -71,10 +68,6 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
         return baseRollCallIntent;
     }
 
-    public ArrayList<InetAddress> getStudentIPs(){
-        return studentIPs;
-    }
-
     @Override
     public void onCreate()
     {
@@ -101,9 +94,6 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
                 currentTeacher = (String) intent.getExtras().getSerializable(TeacherRollCall.ARG_TEACHER);
                 Toast.makeText(getApplicationContext(),"Class Session Started",Toast.LENGTH_LONG).show();
                 break;
-            //case ACTION_GET_STUDENT_IPS:
-            //
-            //    break;
         }
         return START_STICKY;
     }
@@ -119,7 +109,7 @@ public class TeacherRollCallService extends Service implements OnStudentConnectL
         // TODO: add student ID to ArrayList (possibly query from DB)
         Log.d("StudentConnect", "Connected ID: " + id);
         if (ip!=null){
-            studentIPs.add(ip);
+            IPAddressManager.getInstance().addStudentAddress(ip);
             Log.d("StudentConnect", "IP Added: "+ip.toString());
         }
     }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherRollCallAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherRollCallAction.java
@@ -5,8 +5,8 @@
  *   Main ServerSocket that will deal with incoming and outgoing
  *   communications to a students phone (dealing with roll call packets)
  *
- * Edit: 10/7/2015
- *
+ * Edit: 10/12/2015
+ *   Student IP is now collected from the ServerSocket
  *
  */
 

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherRollCallAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherRollCallAction.java
@@ -17,6 +17,7 @@ import android.util.Log;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 
 import edu.uco.schambers.classmate.Fragments.TeacherRollCall;
@@ -54,7 +55,8 @@ public class TeacherRollCallAction extends SocketAction{
             {
                 // TODO: use Student object (check with someone on status, may do myself)
                 String student =(String) objectInputStream.readObject();
-                studentConnectListener.onStudentConnect(student);
+                InetAddress ip = socket.getInetAddress();
+                studentConnectListener.onStudentConnect(student, ip);
                 receiveSuccess = true;
             }
             catch (ClassNotFoundException e)


### PR DESCRIPTION
When student connects to the Teacher's Roll call service their IP is added to the list of IP's in IpAddressManager
- Currently address of student is simply Logged then added to IPAddressManager's list

**Usage**
1. Start Teacher Roll Call Session
2. Check-in as student
3. Check log to see the test student id and the students IP is logged
