### PR TITLE
Start/Stop Class button persistence

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherRollCall.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherRollCall.java
@@ -101,8 +101,16 @@ public class TeacherRollCall extends Fragment {
         token = sp.getString("AUTH_TOKEN", null);
         user = TokenUtility.parseUserToken(token);
 
-        // intialize class_open to false
-        sp.edit().putBoolean(CLASS_OPEN,false).apply();
+        // initialize class_open to false if doesn't exist
+        if(!sp.contains(CLASS_OPEN))
+            sp.edit().putBoolean(CLASS_OPEN,false).apply();
+
+        // set the button's text properly
+        if (sp.getBoolean(CLASS_OPEN,false)) {
+            startBtn.setText(getResources().getString(R.string.btn_roll_call_stop));
+        }else{
+            startBtn.setText(getResources().getString(R.string.btn_roll_call_start));
+        }
 
         teacherText.setText(user.getName().toString());
 


### PR DESCRIPTION
- only small adjust such that the shared preference is not reset every time the fragment is entered
- added code for initializing button text
- If class session is started and fragment is exited, when re-entering the fragment the button still says 'stop class'
