### PR TITLE
Add answer collection from multiple devices

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
@@ -11,6 +11,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
+import edu.uco.schambers.classmate.Models.Questions.DefaultUnanswerdQuestion;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.Services.StudentQuestionService;
@@ -83,12 +84,12 @@ public class TeacherQuestion extends Fragment {
             @Override
             public void onClick(View v) {
                 if (toggle) {
-                    toggleBtn.setText(R.string.btn_teacher_collect);
+                    toggleBtn.setText(R.string.btn_teacher_call_time);
                     sendQuestion();
                     toggle = false;
                 } else {
                     toggleBtn.setText(R.string.btn_teacher_send);
-                    sendCollection();
+                    callTime();
                     toggle = true;
                 }
             }
@@ -96,20 +97,21 @@ public class TeacherQuestion extends Fragment {
 
     }
 
-    //Call to service ****CURRENT****
+
     private void sendQuestion(){
-        //TODO implement sendQuestion method
         IQuestion question = new DefaultMultiChoiceQuestion();
         Intent intent = TeacherQuestionService.getNewSendResponseIntent(getActivity(), question);
-        //TODO create teacherQuestion service and initialize for communication w/ steven
+
         getActivity().startService(intent);
         //stub toast
     }
 
-    private void sendCollection(){
+    private void callTime() {
         //TODO implement sendCollection method
-
+        IQuestion question = new DefaultUnanswerdQuestion(); //Redundent
+        Intent intent = TeacherQuestionService.getNewCallTimeIntent(getActivity(), question);
         //stub toast
+        getActivity().startService(intent);
         Toast.makeText(getActivity(), "Answers collected from class!", Toast.LENGTH_SHORT).show();
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultUnanswerdQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Models/Questions/DefaultUnanswerdQuestion.java
@@ -1,0 +1,41 @@
+package edu.uco.schambers.classmate.Models.Questions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Perrofrijole on 10/27/2015.
+ */
+public class DefaultUnanswerdQuestion implements IQuestion {
+    private List<String> choiceList;
+
+    public DefaultUnanswerdQuestion() {
+        choiceList = new ArrayList<>();
+        choiceList.add("N/A");
+    }
+
+    @Override
+    public String getQuestionText() {
+        return "This question was not answered.";
+    }
+
+    @Override
+    public List<String> getQuestionChoices() {
+        return choiceList;
+    }
+
+    @Override
+    public void answerQuestion(String answer) {
+        //shouldn't happen
+    }
+
+    @Override
+    public boolean questionIsAnswered() {
+        return false;
+    }
+
+    @Override
+    public String getAnswer() {
+        return choiceList.get(0);
+    }
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/TeacherQuestionService.java
@@ -13,11 +13,16 @@ import android.os.Looper;
 import android.support.v4.app.NotificationCompat;
 import android.widget.Toast;
 
+import java.util.ArrayList;
+
 import edu.uco.schambers.classmate.Activites.MainActivity;
 import edu.uco.schambers.classmate.Fragments.StudentResponseFragment;
 import edu.uco.schambers.classmate.Fragments.TeacherQuestion;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
+import edu.uco.schambers.classmate.Models.Questions.DefaultUnanswerdQuestion;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 import edu.uco.schambers.classmate.R;
 import edu.uco.schambers.classmate.SocketActions.SocketAction;
 import edu.uco.schambers.classmate.SocketActions.StudentReceiveQuestionsAction;
@@ -25,36 +30,40 @@ import edu.uco.schambers.classmate.SocketActions.StudentSendQuestionAction;
 import edu.uco.schambers.classmate.SocketActions.TeacherReceiveQuestionsAction;
 import edu.uco.schambers.classmate.SocketActions.TeacherSendQuestionAction;
 
-public class TeacherQuestionService extends Service implements OnQuestionReceivedListener
-{
+public class TeacherQuestionService extends Service implements OnQuestionReceivedListener {
     public static final String ACTION_NOTIFY_QUESTION_RECEIVED = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_NOTIFY_QUESTION_RECEIVED";
     public static final String ACTION_REQUEST_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_REQUEST_QUESTION_RESPONSE";
     public static final String ACTION_SEND_QUESTION_RESPONSE = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_SEND_QUESTION_RESPONSE";
 
-    private SocketAction listenForQuestions;
+    public static final String ACTION_CALL_TIME = "edu.uco.schambers.classmate.Services.TeacherQuestionService.ACTION_CALL_TIME";
 
+    private SocketAction listenForQuestions;
+    private ArrayList<IQuestion> answerList;
+    private boolean isAccepting;
     Handler handler;
 
-    public TeacherQuestionService()
-    {
+    public TeacherQuestionService() {
     }
 
-    public static Intent getNewSendQuestionIntent(Context context, IQuestion question)
-    {
+    public static Intent getNewSendQuestionIntent(Context context, IQuestion question) {
         Intent questionReceivedIntent = getBaseIntent(context,question);
         questionReceivedIntent.setAction(ACTION_NOTIFY_QUESTION_RECEIVED);
         return questionReceivedIntent;
     }
 
-    public static Intent getNewSendResponseIntent(Context context, IQuestion question)
-    {
+    public static Intent getNewSendResponseIntent(Context context, IQuestion question) {
         Intent questionResponseIntent = getBaseIntent(context,question);
         questionResponseIntent.setAction(ACTION_SEND_QUESTION_RESPONSE);
         return questionResponseIntent;
     }
 
-    private static Intent getBaseIntent(Context context, IQuestion question)
-    {
+    public static Intent getNewCallTimeIntent(Context context, IQuestion question) {
+        Intent callTimeIntent = getBaseIntent(context, question);
+        callTimeIntent.setAction(ACTION_CALL_TIME);
+        return callTimeIntent;
+    }
+
+    private static Intent getBaseIntent(Context context, IQuestion question) {
         Intent baseQuestionIntent= new Intent(context, TeacherQuestionService.class);
         Bundle bundle = new Bundle();
         bundle.putSerializable(TeacherQuestion.ARG_QUESTION, question);
@@ -63,43 +72,66 @@ public class TeacherQuestionService extends Service implements OnQuestionReceive
     }
 
     @Override
-    public void onCreate()
-    {
+    public void onCreate() {
         super.onCreate();
         handler = new Handler(Looper.getMainLooper());
+        answerList = new ArrayList<>();
+        isAccepting = false;
         //Todo CARCHER TQS.onCreate() -> SRQA Listener
         listenForQuestions = new TeacherReceiveQuestionsAction(this);
         listenForQuestions.execute();
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId)
-    {
+    public int onStartCommand(Intent intent, int flags, int startId) {
         String action = intent.getAction();
         IQuestion question;
         switch (action)
         {
-            case ACTION_NOTIFY_QUESTION_RECEIVED:
+            case ACTION_NOTIFY_QUESTION_RECEIVED://Question recieved from student, called from listener
                 question = (IQuestion) intent.getExtras().getSerializable(TeacherQuestion.ARG_QUESTION);
+                aggregateQuestion(question);//Add the current answer to the running answer list
                 notifyQuestionReceived(question);
                 break;
-            case ACTION_SEND_QUESTION_RESPONSE:
+            case ACTION_SEND_QUESTION_RESPONSE://Button pressed to send questions to all students
                 question = (IQuestion) intent.getExtras().getSerializable(TeacherQuestion.ARG_QUESTION);
+                isAccepting = true; //Begin accepting Answers
+                balanceAnswerList();
                 sendQuestionResponse(question);
+                break;
+            case ACTION_CALL_TIME://Button to collect answers pressed
+                isAccepting = false;
+                balanceAnswerList();
+                //Update UI/Send to Thomas
                 break;
         }
         return START_STICKY;
     }
 
-    private void sendQuestionResponse(IQuestion question)
-    {
+    private void balanceAnswerList() {
+        if (isAccepting) {
+            answerList.clear();
+        } else {
+            int totalReceived, totalExpected;
+            totalReceived = answerList.size();
+            totalExpected = IPAddressManager.getInstance().getStudentAddresses().size();//Store size in IPAdd?
+            for (int i = 0; i < (totalExpected - totalReceived); i++) {
+                answerList.add(new DefaultUnanswerdQuestion());
+            }
+        }
+    }
+
+    private void sendQuestionResponse(IQuestion question) {
         //Todo CARCHER TQS.sendQuestionResponse() -> SocketAction StudentSQA
         SocketAction sendQuestion = new TeacherSendQuestionAction(question, this);
         sendQuestion.execute();
     }
 
-    private void notifyQuestionReceived(IQuestion question)
-    {
+    private void aggregateQuestion(IQuestion question) {
+        answerList.add(question);
+    }
+
+    private void notifyQuestionReceived(IQuestion question) {
         NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this);
         notificationBuilder.setSmallIcon(R.drawable.ic_stat_question_broadcast_recieved)
@@ -107,7 +139,6 @@ public class TeacherQuestionService extends Service implements OnQuestionReceive
                 .setContentText("Questions Received! Press here to see class aggregate answers!");
         notificationBuilder.setAutoCancel(true);
         notificationBuilder.setPriority(Notification.PRIORITY_HIGH);
-
         Intent notifyIntent = new Intent(this, MainActivity.class);
         notifyIntent.setAction(ACTION_REQUEST_QUESTION_RESPONSE);
         Bundle bundle = new Bundle();
@@ -119,23 +150,38 @@ public class TeacherQuestionService extends Service implements OnQuestionReceive
         notificationManager.notify(R.integer.question_received_notification, notificationBuilder.build());
     }
 
+    /**
+     * Intended to be called from TeacherQuestionResults, will eventually need to check if
+     * the questions have been answered; if sending from TeacherQuestion Fragment may not
+     * need if bundled in intent.
+     *
+     * @return answerList ArrayList<IQuestion> containing all answered/unanswered questions
+     */
+    public ArrayList<IQuestion> getAnswerList() {
+        return answerList;
+    }
+
+    /**
+     * @return isAccepting boolean, true if outstanding question & accepting questions from students
+     */
+    public boolean getIsAccepting() {
+        return isAccepting;
+    }
+
     @Override
-    public IBinder onBind(Intent intent)
-    {
+    public IBinder onBind(Intent intent) {
         // TODO: Return the communication channel to the service.
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
-    public void onQuestionReceived(IQuestion question)
-    {
+    public void onQuestionReceived(IQuestion question) {
         Intent intent = getNewSendQuestionIntent(this, question);
         startService(intent);
     }
 
     @Override
-    public void onQuestionSentSuccessfully(String domain, int port)
-    {
+    public void onQuestionSentSuccessfully(String domain, int port) {
         final String domainFinal = domain;
         final int portFinal = port;
         //Yes, I know this is totally awful. Its not going to stay this way, I swear. Just want these toasts to fire for debug purposes.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="lbl_status_checking_in">Checking in...</string>
     <string name="lbl_status_failed">Check-in failed. Please try again</string>
     <string name="action_debug">Debug</string>
+    <string name="btn_teacher_call_time">Call Time</string>
 
     <string-array name="attendance_list">
         <item>3</item>


### PR DESCRIPTION
This commit adds multi-device answer collection.  Works simply by adding an answered question to the list of answered questions as they come in from students.  When the professor presses "collect", which is now renamed to "call time" answers are no longer accepted from student phones and and missing answers are considered unanswered and stored in the list following the new DefaultUnansweredQuestion format. There is also a getAnswerList() method which returns the list of answered questions for use by Thomas, can be removed later if we decide to only launch the results fragment from my fragment.
