### PR TITLE
Add basic listview for visual reflection of answer collection

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherQuestion.java
@@ -7,8 +7,12 @@ import android.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.ListView;
 import android.widget.Toast;
+
+import java.util.ArrayList;
 
 import edu.uco.schambers.classmate.Models.Questions.DefaultMultiChoiceQuestion;
 import edu.uco.schambers.classmate.Models.Questions.DefaultUnanswerdQuestion;
@@ -32,6 +36,10 @@ public class TeacherQuestion extends Fragment {
 
     // TODO: Rename and change types of parameters
     private IQuestion question;
+
+    private ListView listView;
+    private ArrayList<String> myAnsArray;
+    private ArrayAdapter<String> adapter;
 
     private Button toggleBtn;
 
@@ -78,6 +86,13 @@ public class TeacherQuestion extends Fragment {
 
     private void initUI(final View rootView){
         toggleBtn = (Button) rootView.findViewById(R.id.btn_send_question_propose);
+        myAnsArray = new ArrayList<>();
+        listView = (ListView) rootView.findViewById(R.id.answer_list_view);
+        adapter = new ArrayAdapter<>(getActivity(),
+                android.R.layout.simple_list_item_1, myAnsArray);
+        listView.setAdapter(adapter);
+        listView.setVisibility(View.INVISIBLE);
+
         toggle = true;
 
         toggleBtn.setOnClickListener(new View.OnClickListener() {
@@ -101,8 +116,11 @@ public class TeacherQuestion extends Fragment {
     private void sendQuestion(){
         IQuestion question = new DefaultMultiChoiceQuestion();
         Intent intent = TeacherQuestionService.getNewSendResponseIntent(getActivity(), question);
-
+        listView.setVisibility(View.INVISIBLE);
+        myAnsArray.clear();
         getActivity().startService(intent);
+
+
         //stub toast
     }
 
@@ -110,8 +128,21 @@ public class TeacherQuestion extends Fragment {
         //TODO implement sendCollection method
         IQuestion question = new DefaultUnanswerdQuestion(); //Redundent
         Intent intent = TeacherQuestionService.getNewCallTimeIntent(getActivity(), question);
-        //stub toast
+
         getActivity().startService(intent);
+
+        for (IQuestion q :
+                TeacherQuestionService.answerList) {
+            adapter.add("Student answered: " + q.getAnswer());
+        }
+        /* for testing solo
+        adapter.add("Sttuddy: AAA");
+        adapter.add("Sttuddy: BBB");
+        adapter.add("Sttuddy: CCC");
+        adapter.add("Sttuddy: AAA");
+        adapter.add("Sttuddy: EEE");*/
+        listView.setVisibility(View.VISIBLE);
+
         Toast.makeText(getActivity(), "Answers collected from class!", Toast.LENGTH_SHORT).show();
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherReceiveQuestionsAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/TeacherReceiveQuestionsAction.java
@@ -7,8 +7,10 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.net.ServerSocket;
 
+import edu.uco.schambers.classmate.Fragments.TeacherQuestion;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
+import edu.uco.schambers.classmate.Services.TeacherQuestionService;
 
 /**
  * Created by Steven Chambers on 10/3/2015.
@@ -32,57 +34,52 @@ public class TeacherReceiveQuestionsAction extends SocketAction
     @Override
     void setUpSocket() throws IOException
     {
+
         serverSocket = new ServerSocket(QUESTIONS_PORT_NUMBER);
 
     }
 
     @Override
-    void performAction() throws IOException
-    {
-        while (listeningForQuestions)
-        {
+    void performAction() throws IOException {
+        while (listeningForQuestions) {
             socket = serverSocket.accept();
+
             objectInputStream = new ObjectInputStream(socket.getInputStream());
             dataOutputStream = new DataOutputStream(socket.getOutputStream());
 
-            try
-            {
+            try {
                 IQuestion questionReceived =(IQuestion) objectInputStream.readObject();
                 questionReceivedSuccessfully = true;
                 questionReceivedListener.onQuestionReceived(questionReceived);
-            }
-            catch (ClassNotFoundException e)
-            {
+            } catch (ClassNotFoundException e) {
                 Log.d("SocketAction", "There was a problem decoding the serializable question. Exception: " + e.toString());
             }
             dataOutputStream.writeBoolean(questionReceivedSuccessfully);
-
         }
-
     }
 
     @Override
-    void tearDownSocket() throws IOException
-    {
-        if(serverSocket != null)
-        {
+    void tearDownSocket() throws IOException {
+        if (serverSocket != null) {
             serverSocket.close();
         }
-        if(socket != null)
-        {
+        if (socket != null) {
             socket.close();
         }
-        if(objectInputStream != null)
-        {
+        if (objectInputStream != null) {
             objectInputStream.close();
         }
-        if(dataOutputStream != null)
-        {
+        if (dataOutputStream != null) {
             dataOutputStream.close();
         }
     }
-    public void stopListening()
-    {
+
+    public void stopListening() {
         listeningForQuestions = false;
+    }
+
+    public void startListening() {
+
+        listeningForQuestions = true;
     }
 }

--- a/app/src/main/res/layout/answers_recieved_card.xml
+++ b/app/src/main/res/layout/answers_recieved_card.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/question_propose_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        card_view:cardCornerRadius="4dp">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/answers_returned_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/answers_returned_text"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <ListView
+                android:id="@+id/answer_list_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/answers_returned_text_view"
+                android:layout_alignParentEnd="true"
+                style="?android:borderlessButtonStyle" />
+
+
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_teacher_question.xml
+++ b/app/src/main/res/layout/fragment_teacher_question.xml
@@ -4,7 +4,15 @@
     tools:context="edu.uco.schambers.classmate.Fragments.TeacherQuestion">
 
     <!-- TODO: Update fragment layout -->
-    <include layout="@layout/question_propose_card"/>
+    <include
+        layout="@layout/question_propose_card"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent" />
 
+    <include
+        layout="@layout/answers_recieved_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="130dp" />
 
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="lbl_status_failed">Check-in failed. Please try again</string>
     <string name="action_debug">Debug</string>
     <string name="btn_teacher_call_time">Call Time</string>
+    <string name="answers_returned_text">Answers Recieved:</string>
 
     <string-array name="attendance_list">
         <item>3</item>


### PR DESCRIPTION
This commit adds a listview to the layout so that the answers can be shown on the TeacherQuestion fragment after "Call Time" is pressed.  Probably will be removed once everything is wired to Thomas.  Sets the listview as visible/invisible depending on whether the "Call Time" button has been pressed or if the "Send" button has been pressed.  Also updated the socket connection to check for an active outstanding question before accepting from student devices. For a quick fix also made the ArrayList of answered questions in TeacherQuestionService static for easy access for this demo, it will not stay this way!

The spacing is set manually between the layouts, to adjust change this:
![2015-10-27_1202](https://cloud.githubusercontent.com/assets/13878112/10766019/817460e8-7ca3-11e5-9de8-30fa8f23e6fa.png)
