### PR TITLE
Nelson drop class

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Adapter/EnrollmentAdapter.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Adapter/EnrollmentAdapter.java
@@ -125,4 +125,19 @@ public class EnrollmentAdapter {
         call.execute(new ServiceCall(Url + "Enrollments/", "POST", jsonObject.toString()));
     }
 
+    public void dropClass(int class_id, int user_id, final Callback<HttpResponse> callback) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("Class_Id", class_id);
+        jsonObject.put("User_Id", user_id);
+        ServiceHandlerAsync call = new ServiceHandlerAsync(new Callback<HttpResponse>() {
+
+            @Override
+            public void onComplete(HttpResponse result) throws Exception {
+                callback.onComplete(result);
+            }
+        });
+
+        call.execute(new ServiceCall(Url + "Dropclass/" + class_id + "/" + user_id + "/", "POST", jsonObject.toString()));
+    }
+
 }

--- a/app/src/main/java/edu/uco/schambers/classmate/Adapter/EnrollmentAdapter.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Adapter/EnrollmentAdapter.java
@@ -6,6 +6,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 
 import edu.uco.schambers.classmate.AdapterModels.Class;
@@ -36,7 +38,7 @@ public class EnrollmentAdapter {
         call.execute(new ServiceCall(Url + "schools", "GET", ""));
     }
 
-    public void getYears(String school, final Callback<ArrayList<String>> callback) {
+    public void getYears(String school, final Callback<ArrayList<String>> callback) throws UnsupportedEncodingException {
         ServiceHandlerAsync call = new ServiceHandlerAsync(new Callback<HttpResponse>() {
             @Override
             public void onComplete(HttpResponse response) throws Exception {
@@ -55,10 +57,12 @@ public class EnrollmentAdapter {
             }
         });
 
-        call.execute(new ServiceCall(Url + "years/" + school, "GET", ""));
+        String url = Url + "years/" + URLEncoder.encode(school, "UTF-8").replace("+", "%20");
+
+        call.execute(new ServiceCall(url, "GET", ""));
     }
 
-    public void getSemesters(String school, String year, final Callback<ArrayList<String>> callback) {
+    public void getSemesters(String school, String year, final Callback<ArrayList<String>> callback) throws UnsupportedEncodingException {
         ServiceHandlerAsync call = new ServiceHandlerAsync(new Callback<HttpResponse>() {
             @Override
             public void onComplete(HttpResponse response) throws Exception {
@@ -77,10 +81,10 @@ public class EnrollmentAdapter {
             }
         });
 
-        call.execute(new ServiceCall(Url + "semesters/" + school + "/" + year, "GET", ""));
+        call.execute(new ServiceCall(Url + "semesters/" + URLEncoder.encode(school, "UTF-8").replace("+", "%20") + "/" + year, "GET", ""));
     }
 
-    public void getClasses(String school, final String year, final String semester, int studentId, final Callback<ArrayList<Class>> callback) {
+    public void getClasses(String school, final String year, final String semester, int studentId, final Callback<ArrayList<Class>> callback) throws UnsupportedEncodingException {
         ServiceHandlerAsync call = new ServiceHandlerAsync(new Callback<HttpResponse>() {
             @Override
             public void onComplete(HttpResponse response) throws Exception {
@@ -107,7 +111,7 @@ public class EnrollmentAdapter {
             }
         });
 
-        call.execute(new ServiceCall(Url + "classes/" + school + "/" + year + "/" + semester + "/" + studentId, "GET", ""));
+        call.execute(new ServiceCall(Url + "classes/" + URLEncoder.encode(school, "UTF-8").replace("+", "%20") + "/" + year + "/" + semester + "/" + studentId, "GET", ""));
     }
 
     public void classEnroll(int user_id, int class_id, final Callback<HttpResponse> callback) throws JSONException {

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentEnrollment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentEnrollment.java
@@ -310,13 +310,15 @@ public class StudentEnrollment extends Fragment {
                 @Override
                 public void onClick(View v) {
                     try {
-                        enrollmentAdapter.classEnroll(TokenUtility.parseUserToken(getActivity()).getId(), classItem.getId(), new Callback<HttpResponse>() {
+                        enrollmentAdapter.classEnroll(TokenUtility.parseUserToken(getActivity()).getpKey(), classItem.getId(), new Callback<HttpResponse>() {
                             @Override
                             public void onComplete(HttpResponse result) throws Exception {
                                 Log.d("EnrollDebug", "Enroll result" + result);
                                 if(result.getHttpCode() == 409){
                                     Toast.makeText(getActivity(), "Cant Enroll in the same class twice", Toast.LENGTH_LONG).show();
-                                }else{
+                                } else if (result.getHttpCode() >= 400) {
+                                    Toast.makeText(getActivity(), "Error occurred", Toast.LENGTH_LONG).show();
+                                } else{
                                     Toast.makeText(getActivity(), "Enrollment was Successful ", Toast.LENGTH_LONG).show();
                                     c2.setEnabled(false);
                                     c2.setText("Enrolled");

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentEnrollment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentEnrollment.java
@@ -33,6 +33,7 @@ import android.widget.Toast;
 
 import org.json.JSONException;
 
+import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -129,7 +130,7 @@ public class StudentEnrollment extends Fragment {
         semesterList = new ArrayList<>();
 
         // instantiate array adapters for each object
-        schoolAdapter = new ArrayAdapter<String>(getActivity(),android.R.layout.simple_list_item_1, schoolList);
+        schoolAdapter = new ArrayAdapter<String>(getActivity(),android.R.layout.simple_spinner_dropdown_item, schoolList);
         yearAdapter = new ArrayAdapter<String>(getActivity(),android.R.layout.simple_spinner_dropdown_item, yearList);
         semesterAdapter = new ArrayAdapter<String>(getActivity(),android.R.layout.simple_spinner_dropdown_item, semesterList);
 
@@ -158,22 +159,26 @@ public class StudentEnrollment extends Fragment {
             @Override
             public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
                 String selectedSchool = school.getSelectedItem().toString();
-                enrollmentAdapter.getYears(selectedSchool, new Callback<ArrayList<String>>() {
-                    @Override
-                    public void onComplete(ArrayList<String> result) throws Exception {
-                        yearList.clear();
-                        yearList.add("Select Year");
-                        for (String year : result) {
-                            yearList.add(year);
+                try {
+                    enrollmentAdapter.getYears(selectedSchool, new Callback<ArrayList<String>>() {
+                        @Override
+                        public void onComplete(ArrayList<String> result) throws Exception {
+                            yearList.clear();
+                            yearList.add("Select Year");
+                            for (String year : result) {
+                                yearList.add(year);
+                            }
+                            yearAdapter.notifyDataSetChanged();
+                            year.setEnabled(true);
+                            year.setSelection(0);
+                            semesterList.clear();
+                            semesterAdapter.notifyDataSetChanged();
+                            semester.setEnabled(false);
                         }
-                        yearAdapter.notifyDataSetChanged();
-                        year.setEnabled(true);
-                        year.setSelection(0);
-                        semesterList.clear();
-                        semesterAdapter.notifyDataSetChanged();
-                        semester.setEnabled(false);
-                    }
-                });
+                    });
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
 
                 resetTable();
             }
@@ -192,19 +197,23 @@ public class StudentEnrollment extends Fragment {
                 }
                 String selectedSchool = school.getSelectedItem().toString();
                 String selectedYear = year.getSelectedItem().toString();
-                enrollmentAdapter.getSemesters(selectedSchool, selectedYear, new Callback<ArrayList<String>>() {
-                    @Override
-                    public void onComplete(ArrayList<String> result) throws Exception {
-                        semesterList.clear();
-                        semesterList.add("Select Semester");
-                        for (String semester : result) {
-                            semesterList.add(semester);
+                try {
+                    enrollmentAdapter.getSemesters(selectedSchool, selectedYear, new Callback<ArrayList<String>>() {
+                        @Override
+                        public void onComplete(ArrayList<String> result) throws Exception {
+                            semesterList.clear();
+                            semesterList.add("Select Semester");
+                            for (String semester : result) {
+                                semesterList.add(semester);
+                            }
+                            semesterAdapter.notifyDataSetChanged();
+                            semester.setEnabled(true);
+                            semester.setSelection(0);
                         }
-                        semesterAdapter.notifyDataSetChanged();
-                        semester.setEnabled(true);
-                        semester.setSelection(0);
-                    }
-                });
+                    });
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
 
                 resetTable();
             }
@@ -234,7 +243,7 @@ public class StudentEnrollment extends Fragment {
                             buildTable();
                         }
                     });
-                } catch (JSONException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }

--- a/app/src/main/res/layout/fragment_student_enrollment.xml
+++ b/app/src/main/res/layout/fragment_student_enrollment.xml
@@ -22,6 +22,12 @@
                 android:spinnerMode="dropdown"
                 android:layout_weight="0.5"/>
 
+        </TableRow>
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:baselineAligned="false">
+
             <Spinner
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
-Fixed issue (Student Enrollment Data Not Reflected in Teacher Attendance Interface #95)
-Changed enrollment UI(School spinner now on its own table row, which can fit the complete school name). Reason for this change: Some schools have the same abbreviated name. 
- Added a function in the EnrollmentAdapter to drop class. The student can only drop a class if they have not attended class. The httpRespose that is thrown by web API is 403 if the student has an attendance record.
  Note: These changes are not for the sprint due tonight(sprint 4). They should be included in the next sprint(Sprint 5).
