### PR TITLE
Sc question fault tolerance

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -76,7 +76,7 @@ public class StudentResponseFragment extends Fragment
 
     protected void setUpQuestionCard()
     {
-        if(questionCardView == null)
+        if (questionCardView == null)
         {
             questionCardView = getActivity().getLayoutInflater().inflate(R.layout.question_response_card, null);
             ((ViewGroup) rootView).addView(questionCardView);
@@ -94,6 +94,12 @@ public class StudentResponseFragment extends Fragment
             {
                 case StudentQuestionService.MSG_QUESTION_RECEIEVED:
                     loadQuestionWithAnimation();
+                    break;
+                case StudentQuestionService.MSG_QUESTION_SEND_ERROR:
+                    displayErrorAndErrorAnimation(msg.obj);
+                    break;
+                case StudentQuestionService.MSG_QUESTION_SEND_SUCCESS:
+                    displaySuccessAndSuccessAnimation();
                 default:
                     super.handleMessage(msg);
             }
@@ -108,9 +114,22 @@ public class StudentResponseFragment extends Fragment
         incommingQuestionAnimation();
     }
 
+    private void displayErrorAndErrorAnimation(Object obj)
+    {
+        String message = (String) obj;
+        Toast.makeText(getActivity(), message, Toast.LENGTH_LONG).show();
+        sendBtn.setEnabled(true);
+    }
+
+    private void displaySuccessAndSuccessAnimation()
+    {
+        Toast.makeText(getActivity(),"The question response was sent successfully!", Toast.LENGTH_LONG).show();
+        dismissCardAnimation();
+    }
+
     private void incommingQuestionAnimation()
     {
-        Animation slideInLeft= AnimationUtils.loadAnimation(getActivity(), android.R.anim.slide_in_left);
+        Animation slideInLeft = AnimationUtils.loadAnimation(getActivity(), android.R.anim.slide_in_left);
         slideInLeft.setAnimationListener(new Animation.AnimationListener()
         {
             @Override
@@ -177,7 +196,7 @@ public class StudentResponseFragment extends Fragment
     @Override
     public void onPause()
     {
-        if(questionServiceIsBound)
+        if (questionServiceIsBound)
         {
             getActivity().unbindService(serviceConnection);
         }
@@ -229,9 +248,9 @@ public class StudentResponseFragment extends Fragment
     private void sendResponse(IQuestion question)
     {
         //TODO implement send method
-        Intent questionResponseIntent = StudentQuestionService.getNewSendResponseIntent(getActivity(),question);
+        sendBtn.setEnabled(false);
+        Intent questionResponseIntent = StudentQuestionService.getNewSendResponseIntent(getActivity(), question);
         getActivity().startService(questionResponseIntent);
-        dismissCardAnimation();
     }
 
     private void dismissCardAnimation()
@@ -262,7 +281,7 @@ public class StudentResponseFragment extends Fragment
 
     private void destroyQuestionCard()
     {
-        ((ViewGroup)questionCardView.getParent()).removeView(questionCardView);
+        ((ViewGroup) questionCardView.getParent()).removeView(questionCardView);
         questionCardView = null;
     }
 

--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/StudentResponseFragment.java
@@ -119,6 +119,13 @@ public class StudentResponseFragment extends Fragment
         String message = (String) obj;
         Toast.makeText(getActivity(), message, Toast.LENGTH_LONG).show();
         sendBtn.setEnabled(true);
+        shakeQuestionCard();
+    }
+
+    private void shakeQuestionCard()
+    {
+        Animation shake = AnimationUtils.loadAnimation(getActivity(), R.anim.shake);
+        questionCardView.startAnimation(shake);
     }
 
     private void displaySuccessAndSuccessAnimation()

--- a/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionSendErrorListener.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/ListenerInterfaces/OnQuestionSendErrorListener.java
@@ -1,0 +1,9 @@
+package edu.uco.schambers.classmate.ListenerInterfaces;
+
+/**
+ * Created by Steven Chambers on 10/31/2015.
+ */
+public interface OnQuestionSendErrorListener
+{
+    void onQuestionSendError(String message);
+}

--- a/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Services/StudentQuestionService.java
@@ -178,18 +178,15 @@ public class StudentQuestionService extends Service implements OnQuestionReceive
         this.question = null;
         NotificationManager notificationManager = (NotificationManager) getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancel(R.integer.question_received_notification);
-        final String domainFinal = domain;
-        final int portFinal = port;
-        //Yes, I know this is totally awful. Its not going to stay this way, I swear. Just want these toasts to fire for debug purposes.
-        handler.post(new Runnable()
-        {
-            @Override
 
-            public void run()
-            {
-                Toast.makeText(getBaseContext(), String.format("The question was sent successfully to domain: %s port %d ", domainFinal, portFinal), Toast.LENGTH_LONG).show();
-            }
-        });
+        Message successMessage = Message.obtain(null, MSG_QUESTION_SEND_SUCCESS, 0, 0);
+        try
+        {
+            fragmentMessenger.send(successMessage);
+        }catch (RemoteException e)
+        {
+            Log.d("StudentQuestionService", String.format("Message failed. Exception: %s", e.toString()));
+        }
     }
 
     @Override

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -47,7 +47,7 @@ public class StudentSendQuestionAction extends SocketAction
             dataInputStream = new DataInputStream(socket.getInputStream());
         }catch (IOException e)
         {
-
+            questionSendErrorListener.onQuestionSendError("There was an error sending the question: Class session not found.");
         }
     }
 
@@ -63,7 +63,7 @@ public class StudentSendQuestionAction extends SocketAction
             questionSentSuccessfully = dataInputStream.readBoolean();
         }catch(IOException e)
         {
-
+            questionSendErrorListener.onQuestionSendError("There was an error sending the question: Please try again soon.");
         }
 
         if (questionSentSuccessfully)

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -11,6 +11,7 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
+import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionSendErrorListener;
 import edu.uco.schambers.classmate.Models.Questions.IQuestion;
 import edu.uco.schambers.classmate.ObservableManagers.IPAddressManager;
 
@@ -25,6 +26,7 @@ public class StudentSendQuestionAction extends SocketAction
 
     IQuestion questionToSend;
     OnQuestionReceivedListener questionReceivedListener;
+    OnQuestionSendErrorListener questionSendErrorListener;
 
     boolean questionSentSuccessfully;
 
@@ -32,42 +34,56 @@ public class StudentSendQuestionAction extends SocketAction
     {
         this.questionToSend = question;
         this.questionReceivedListener = listener;
+        this.questionSendErrorListener = (OnQuestionSendErrorListener) listener;
     }
 
     @Override
-    void setUpSocket() throws UnknownHostException, IOException
+    void setUpSocket()
     {
-        socket = new Socket(domain, QUESTIONS_PORT_NUMBER);
-        objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
-        dataInputStream = new DataInputStream(socket.getInputStream());
-    }
-
-    @Override
-    void performAction() throws IOException
-    {
-        if (questionToSend != null)
+        try
         {
-            objectOutputStream.writeObject(questionToSend);
+            socket = new Socket(domain, QUESTIONS_PORT_NUMBER);
+            objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
+            dataInputStream = new DataInputStream(socket.getInputStream());
+        }catch (IOException e)
+        {
+
         }
-        questionSentSuccessfully = dataInputStream.readBoolean();
-        if(questionSentSuccessfully)
+    }
+
+    @Override
+    void performAction()
+    {
+        try
         {
-            questionReceivedListener.onQuestionSentSuccessfully(domain,QUESTIONS_PORT_NUMBER);
+            if (questionToSend != null)
+            {
+                objectOutputStream.writeObject(questionToSend);
+            }
+            questionSentSuccessfully = dataInputStream.readBoolean();
+        }catch(IOException e)
+        {
+
+        }
+
+        if (questionSentSuccessfully)
+        {
+            questionReceivedListener.onQuestionSentSuccessfully(domain, QUESTIONS_PORT_NUMBER);
         }
     }
 
     @Override
     void tearDownSocket() throws IOException
     {
-        if(socket != null)
+        if (socket != null)
         {
             socket.close();
         }
-        if(dataInputStream != null)
+        if (dataInputStream != null)
         {
             dataInputStream.close();
         }
-        if(objectOutputStream != null)
+        if (objectOutputStream != null)
         {
             objectOutputStream.close();
         }

--- a/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/SocketActions/StudentSendQuestionAction.java
@@ -7,8 +7,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeoutException;
 
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionReceivedListener;
 import edu.uco.schambers.classmate.ListenerInterfaces.OnQuestionSendErrorListener;
@@ -29,6 +32,7 @@ public class StudentSendQuestionAction extends SocketAction
     OnQuestionSendErrorListener questionSendErrorListener;
 
     boolean questionSentSuccessfully;
+    boolean socketConnectionSuccess = true;
 
     public StudentSendQuestionAction(IQuestion question, OnQuestionReceivedListener listener)
     {
@@ -42,12 +46,14 @@ public class StudentSendQuestionAction extends SocketAction
     {
         try
         {
-            socket = new Socket(domain, QUESTIONS_PORT_NUMBER);
+            socket = new Socket();
+            socket.connect(new InetSocketAddress(domain, QUESTIONS_PORT_NUMBER), 1000);
             objectOutputStream = new ObjectOutputStream(socket.getOutputStream());
             dataInputStream = new DataInputStream(socket.getInputStream());
-        }catch (IOException e)
+        }catch (Exception e)
         {
             questionSendErrorListener.onQuestionSendError("There was an error sending the question: Class session not found.");
+            socketConnectionSuccess = false;
         }
     }
 
@@ -56,12 +62,12 @@ public class StudentSendQuestionAction extends SocketAction
     {
         try
         {
-            if (questionToSend != null)
+            if (socketConnectionSuccess && questionToSend != null)
             {
                 objectOutputStream.writeObject(questionToSend);
+                questionSentSuccessfully = dataInputStream.readBoolean();
             }
-            questionSentSuccessfully = dataInputStream.readBoolean();
-        }catch(IOException e)
+        }catch(Exception e)
         {
             questionSendErrorListener.onQuestionSendError("There was an error sending the question: Please try again soon.");
         }

--- a/app/src/main/res/anim/shake.xml
+++ b/app/src/main/res/anim/shake.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="-25"
+        android:toXDelta="25"
+        android:repeatCount="5"
+        android:repeatMode="reverse"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:duration="100" />
+</set>


### PR DESCRIPTION
This update adds error message support / animations if a question is not able to be sent correctly. In addition the service now notifies the student question fragment when a question has been sent out successfully, instead of the fragment always assuming that sending was successful.

To test this functionality:
1. start a roll call service on teachers phone and check in with student phone
2. enter the in class response fragments on both phones
3. send a question from the teacher device
4. after question is received on student device, turn off the wifi on the teachers phone to simulate a connection disruption.
5. watch the question on the students phone shake back and forth instead of being sent out to the right and observe the toast giving an error message. 
