### PR TITLE
fixed TeacherAttendance

### DIFF
--- a/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherAttendance.java
+++ b/app/src/main/java/edu/uco/schambers/classmate/Fragments/TeacherAttendance.java
@@ -318,7 +318,7 @@ public class TeacherAttendance extends Fragment {
             TextView c0 = new TextView(view.getContext());
             c0.setText(student.getName());
             TextView c2 = new TextView(view.getContext());
-            c2.setText(String.valueOf(4)); //student.getAbsences())
+            c2.setText(String.valueOf(student.getAbsences())); //student.getAbsences())
             //Add the data to the row
             tr.addView(c0);
             tr.addView(c2);


### PR DESCRIPTION
-Fixed teacher attendance for students
-RollCall and attendance works on the web service(Tested it using Postman by sending raw Json array)

Note: The query on the web service only checks if the student was present in class that day. This means the student will be mark as present, if they were present that day. To avoid conflict Teacher should only take rollCall for a class once in a day, this is due to the way the attendance is being queried. 
