### PR TITLE
fix borderless button display bug

### DIFF
--- a/app/src/main/res/layout/question_propose_card.xml
+++ b/app/src/main/res/layout/question_propose_card.xml
@@ -34,6 +34,8 @@
                 android:layout_below="@id/propose_card_question_text"
                 android:layout_alignParentEnd="true"
                 style="?android:borderlessButtonStyle"
+                android:textColor="#1565C0"
+                android:textStyle="bold"
                 />
 
 

--- a/app/src/main/res/layout/question_response_card.xml
+++ b/app/src/main/res/layout/question_response_card.xml
@@ -52,6 +52,8 @@
                 android:layout_below="@+id/radio_response_group"
                 android:layout_alignParentEnd="true"
                 style="?android:borderlessButtonStyle"
+                android:textColor="#1565C0"
+                android:textStyle="bold"
                 />
 
 


### PR DESCRIPTION
Fixes #135 

Text colors and styles for the borderless buttons used in the Question Center are now overide the base style to correct the appearance of the buttons.
